### PR TITLE
🔒 Fix YAML injection vulnerability in frontmatter generation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1828,7 +1828,7 @@ export default class RaindropToObsidian extends Plugin implements IRaindropToObs
 
             const escapeYamlStringValue = (str: string | undefined | null): string => {
                 if (str === undefined || str === null) return '';
-                return str.replace(/"/g, '\\"'); // Escape double quotes for YAML
+                return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"'); // Escape double quotes for YAML
             };
 
             const generatedFilename = this.generateFileName(raindrop, options.useRaindropTitleForFileName);
@@ -1918,7 +1918,7 @@ export default class RaindropToObsidian extends Plugin implements IRaindropToObs
                         if (excerpt.includes('\n')) {
                             descriptionYaml = `description: |\n${excerpt.split('\n').map((line: string) => `  ${line}`).join('\n')}`;
                         } else {
-                            descriptionYaml = `description: "${excerpt.replace(/"/g, '\\"')}"`;
+                            descriptionYaml = `description: "${excerpt.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
                         }
                     } else {
                         descriptionYaml = `description: ""`;
@@ -1926,7 +1926,7 @@ export default class RaindropToObsidian extends Plugin implements IRaindropToObs
 
                     let frontmatter = `---\n`;
                     frontmatter += `id: ${id}\n`;
-                    frontmatter += `title: "${title.replace(/"/g, '\\"')}"\n`;
+                    frontmatter += `title: "${title.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"\n`;
                     frontmatter += `${descriptionYaml}\n`;
                     frontmatter += `source: ${link}\n`;
                     frontmatter += `type: ${type}\n`;
@@ -2146,7 +2146,7 @@ export default class RaindropToObsidian extends Plugin implements IRaindropToObs
                 }
                 
                 // Otherwise use quoted string with escaping
-                return `"${value.replace(/"/g, '\\"')}"`;
+                return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
             }
             return value;
         }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Fixed invalid string escaping for YAML generation in `src/main.ts` where backslashes were not being escaped.

⚠️ **Risk:** The potential impact if left unfixed
A trailing backslash could escape the YAML quote boundary (e.g. `\"`), allowing an attacker to inject arbitrary YAML keys into the frontmatter.

🛡️ **Solution:** How the fix addresses the vulnerability
Updated the `.replace` chains to replace backslashes with double backslashes before escaping double quotes: `.replace(/\\/g, '\\\\').replace(/\"/g, '\\\"')`.

---
*PR created automatically by Jules for task [14330324613203147638](https://jules.google.com/task/14330324613203147638) started by @frostmute*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced YAML string escaping to properly handle backslashes and quotation marks, preventing formatting issues when processing strings with these special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->