### PR TITLE
🔒 [security fix] Sanitize input in RegExp constructor

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -57,7 +57,8 @@ import {
     formatDateISO,
     formatTags,
     getDomain,
-    raindropType
+    raindropType,
+    escapeRegExp
 } from './utils';
 
 
@@ -231,7 +232,7 @@ export default class RaindropToObsidian extends Plugin implements IRaindropToObs
         
         const replacePlaceholder = (placeholder: string, value: string) => {
             const safeValue = sanitizeFileName(value);
-            const regex = new RegExp(`{{${placeholder}}}`, 'gi');
+            const regex = new RegExp(`{{${escapeRegExp(placeholder)}}}`, 'gi');
             fileName = fileName.replace(regex, safeValue);
         };
 

--- a/src/utils/formatUtils.ts
+++ b/src/utils/formatUtils.ts
@@ -43,3 +43,12 @@ export function raindropType(type: string): string {
     };
     return types[type as keyof typeof types] || type;
 }
+
+/**
+ * Escapes special characters in a string for use in a regular expression
+ * @param str - The string to escape
+ * @returns The escaped string
+ */
+export function escapeRegExp(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -71,6 +71,7 @@ export {
     formatDateISO,
     formatTags,
     getDomain,
-    raindropType
+    raindropType,
+    escapeRegExp
 } from './formatUtils';
 

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -121,6 +121,26 @@ describe('RaindropToObsidian', () => {
             const fileName = plugin.generateFileName(raindrop, true);
             expect(fileName).toBe('Test  Raindrop Illegal');
         });
+
+        it('should correctly handle placeholders with regex special characters', () => {
+            const raindrop = {
+                _id: 123,
+                title: 'Test Raindrop',
+                link: 'https://test.com',
+                created: '2024-01-01T12:00:00Z',
+                lastUpdate: '2024-01-01T12:00:00Z',
+                type: 'link' as RaindropType
+            } as RaindropItem;
+
+            // This test is a bit artificial because replacePlaceholder is an internal function
+            // that is currently only called with hardcoded strings.
+            // But if we were to allow a dynamic placeholder, this ensures it's safe.
+            // We'll test it indirectly by ensuring the current logic still works with standard templates
+            // and the formatUtils tests cover the actual escaping logic.
+            plugin.settings.fileNameTemplate = '{{title}}';
+            const fileName = plugin.generateFileName(raindrop, true);
+            expect(fileName).toBe('Test Raindrop');
+        });
     });
 
     describe('updateRibbonIcon', () => {

--- a/tests/unit/utils/formatUtils.test.ts
+++ b/tests/unit/utils/formatUtils.test.ts
@@ -1,0 +1,39 @@
+import { escapeRegExp } from '../../../src/utils/formatUtils';
+
+describe('formatUtils', () => {
+    describe('escapeRegExp', () => {
+        it('should escape special regex characters', () => {
+            const input = '.*+?^${}()|[]\\';
+            const expected = '\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\';
+            expect(escapeRegExp(input)).toBe(expected);
+        });
+
+        it('should not escape alphanumeric characters', () => {
+            const input = 'abcABC123';
+            expect(escapeRegExp(input)).toBe(input);
+        });
+
+        it('should handle empty string', () => {
+            expect(escapeRegExp('')).toBe('');
+        });
+
+        it('should handle strings with no special characters', () => {
+            const input = 'hello world';
+            expect(escapeRegExp(input)).toBe(input);
+        });
+
+        it('should escape characters in the middle of a string', () => {
+            const input = 'hello.world';
+            const expected = 'hello\\.world';
+            expect(escapeRegExp(input)).toBe(expected);
+        });
+
+        it('should work correctly in a RegExp constructor', () => {
+            const placeholder = 'title(copy)';
+            const escaped = escapeRegExp(placeholder);
+            const regex = new RegExp(`{{${escaped}}}`, 'gi');
+            const template = 'Hello {{title(copy)}}';
+            expect(template.replace(regex, 'world')).toBe('Hello world');
+        });
+    });
+});


### PR DESCRIPTION
🎯 **What:** Fixed an unsanitized input vulnerability in the `RegExp` constructor within `src/main.ts`.
⚠️ **Risk:** Potential for Regular Expression injection or unexpected behavior if dynamic placeholders were to be used in the future.
🛡️ **Solution:** Implemented a new `escapeRegExp` utility function in `src/utils/formatUtils.ts` and applied it to the `placeholder` variable in `src/main.ts` before creating the `RegExp` object. This ensures that any special characters in the placeholder name are treated as literals. Added comprehensive unit tests for the new utility and updated the plugin's unit tests.

---
*PR created automatically by Jules for task [15262920675332223068](https://jules.google.com/task/15262920675332223068) started by @frostmute*