### PR TITLE
🧹 remove unused import RaindropType in apiUtils.ts

### DIFF
--- a/src/utils/apiUtils.ts
+++ b/src/utils/apiUtils.ts
@@ -1,6 +1,6 @@
 import { App, request } from 'obsidian';
 import { sanitizeFileName } from './fileUtils';
-import { RaindropCollection, RaindropType } from '../types';
+import { RaindropCollection } from '../types';
 
 
 /**


### PR DESCRIPTION
🎯 **What:** Removed the unused import `RaindropType` from `src/utils/apiUtils.ts`.
💡 **Why:** This improves maintainability and readability by cleaning up dead code and resolving ESLint flags.
✅ **Verification:** Ran `tests/unit/utils/apiUtils.test.ts` and all 38 tests passed.
✨ **Result:** A cleaner codebase with one less unused variable.

---
*PR created automatically by Jules for task [2855403958225210886](https://jules.google.com/task/2855403958225210886) started by @frostmute*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frostmute/make-it-rain/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->