### PR TITLE
🔒 Fix frontmatter injection vulnerability in folder note generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "make-it-rain",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "make-it-rain",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "license": "MIT",
       "dependencies": {
         "@types/handlebars": "^4.0.40",

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,7 +64,7 @@ import {
     // Template utilities
     ASTNode,
     parseTemplate
-} from './utils';
+, createYamlFrontmatter } from './utils';
 
 // System collection IDs from raindrop.io API docs
 const SystemCollections = {
@@ -542,7 +542,8 @@ export default class RaindropToObsidian extends Plugin implements IRaindropToObs
                     const folderNotePath = normalizePath(`${folderPath}/${folderName}.md`);
                     const abstractFile = app.vault.getAbstractFileByPath(folderPath);
                     if (abstractFile instanceof TFolder) {
-                        let content = `---\ntitle: "${folderName.replace(/"/g, '\\"')}"\ntype: collection\n---\n\n# ${folderName}\n\n## Collection Contents\n\n`;
+                        const frontmatter = createYamlFrontmatter({ title: folderName, type: 'collection' });
+                        let content = `${frontmatter}# ${folderName}\n\n## Collection Contents\n\n`;
                         const listItems = abstractFile.children
                             .filter((child: TAbstractFile) => child.name !== `${folderName}.md`)
                             .sort((a: TAbstractFile, b: TAbstractFile) => a.name.localeCompare(b.name))

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,8 +63,9 @@ import {
 
     // Template utilities
     ASTNode,
-    parseTemplate
-, createYamlFrontmatter } from './utils';
+    parseTemplate,
+    createYamlFrontmatter
+} from './utils';
 
 // System collection IDs from raindrop.io API docs
 const SystemCollections = {


### PR DESCRIPTION
🎯 **What:** 
Fixed a vulnerability in `src/main.ts` where insufficient sanitization of `folderName` could allow for YAML frontmatter injection.

⚠️ **Risk:** 
When generating folder notes during collection creation, the `folderName` string was interpolated into the raw template with only double quotes (`"`) replaced via regex. As the comment for `escapeYamlString` indicates, newlines are not escaped there. If a user synced a Raindrop collection containing newline characters (e.g., via a nested collection name), it would break the YAML structure and could allow arbitrary frontmatter property injection into the Obsidian file.

🛡️ **Solution:** 
Refactored the frontmatter string generation around line 545 to use the centralized and secure `createYamlFrontmatter` utility function from `src/utils`. This securely formats the object into correct YAML utilizing the proper block scalar serialization syntax in case of embedded newlines or any other special characters.

---
*PR created automatically by Jules for task [12351978211319288703](https://jules.google.com/task/12351978211319288703) started by @frostmute*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frostmute/make-it-rain/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->