### PR TITLE
🧹 [code health improvement] Remove unused settings parameter in validateTemplate

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -412,7 +412,7 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
             .addText((text: TextComponent) => {
                 const validationContainer = orgContent.createDiv('make-it-rain-validation-container');
                 const updateValidation = (val: string) => {
-                    const result = validateTemplate(val, this.plugin.settings);
+                    const result = validateTemplate(val);
                     this.renderValidationResult(validationContainer, result);
                 };
 
@@ -535,7 +535,7 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                 .addTextArea((text: TextAreaComponent) => {
                     const validationContainer = templateContent.createDiv('make-it-rain-validation-container');
                     const updateValidation = (val: string) => {
-                        const result = validateTemplate(val, this.plugin.settings);
+                        const result = validateTemplate(val);
                         this.renderValidationResult(validationContainer, result);
                     };
 
@@ -609,7 +609,7 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                     .addTextArea((text: TextAreaComponent) => {
                         const validationContainer = editorCard.createDiv('make-it-rain-validation-container');
                         const updateValidation = (val: string) => {
-                            const result = validateTemplate(val, this.plugin.settings);
+                            const result = validateTemplate(val);
                             this.renderValidationResult(validationContainer, result);
                         };
 
@@ -771,7 +771,7 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                 .addTextArea((text) => {
                     const validationContainer = templateDiv.createDiv('make-it-rain-validation-container');
                     const updateValidation = (val: string) => {
-                        const result = validateTemplate(val, this.plugin.settings);
+                        const result = validateTemplate(val);
                         this.renderValidationResult(validationContainer, result);
                     };
 

--- a/src/template-validator.ts
+++ b/src/template-validator.ts
@@ -1,5 +1,4 @@
 import { parseTemplate, ASTNode } from './utils';
-import { MakeItRainSettings } from './types';
 
 export interface ValidationResult {
     isValid: boolean;
@@ -7,7 +6,7 @@ export interface ValidationResult {
     warnings: string[];
 }
 
-export function validateTemplate(template: string, settings: MakeItRainSettings): ValidationResult {
+export function validateTemplate(template: string): ValidationResult {
     const result: ValidationResult = {
         isValid: true,
         errors: [],

--- a/tests/unit/templateValidator.test.ts
+++ b/tests/unit/templateValidator.test.ts
@@ -1,68 +1,64 @@
 import { validateTemplate } from '../../src/template-validator';
-import { DEFAULT_SETTINGS } from '../../src/settings';
-
 describe('Template Validator', () => {
-    const settings = DEFAULT_SETTINGS;
-
     test('should validate a simple valid template', () => {
         const template = '# {{title}}\n{{excerpt}}';
-        const result = validateTemplate(template, settings);
+        const result = validateTemplate(template);
         expect(result.isValid).toBe(true);
         expect(result.errors).toHaveLength(0);
     });
 
     test('should detect unclosed if tags', () => {
         const template = '{{#if title}} Unclosed';
-        const result = validateTemplate(template, settings);
+        const result = validateTemplate(template);
         expect(result.isValid).toBe(false);
         expect(result.errors[0]).toContain('Unclosed #if tag');
     });
 
     test('should detect unclosed each tags', () => {
         const template = '{{#each tags}} {{this}}';
-        const result = validateTemplate(template, settings);
+        const result = validateTemplate(template);
         expect(result.isValid).toBe(false);
         expect(result.errors[0]).toContain('Unclosed #each tag');
     });
 
     test('should detect unclosed extends tags', () => {
         const template = '{{#extends "base"}} Content';
-        const result = validateTemplate(template, settings);
+        const result = validateTemplate(template);
         expect(result.isValid).toBe(false);
         expect(result.errors[0]).toContain('Unclosed #extends tag');
     });
 
     test('should detect unclosed block tags', () => {
         const template = '{{#block "main"}} Content';
-        const result = validateTemplate(template, settings);
+        const result = validateTemplate(template);
         expect(result.isValid).toBe(false);
         expect(result.errors[0]).toContain('Unclosed #block tag');
     });
 
     test('should warn about possibly unknown variables', () => {
         const template = '{{unknown_var}}';
-        const result = validateTemplate(template, settings);
+        const result = validateTemplate(template);
         expect(result.isValid).toBe(true);
         expect(result.warnings).toContain('Possibly unknown variable: {{unknown_var}}');
     });
 
     test('should warn about unknown helpers', () => {
         const template = '{{unknown_helper title}}';
-        const result = validateTemplate(template, settings);
+        const result = validateTemplate(template);
         expect(result.isValid).toBe(true);
         expect(result.warnings).toContain('Unknown helper: {{unknown_helper}}');
     });
 
     test('should detect unclosed YAML frontmatter', () => {
         const template = '---\ntitle: test\n# missing closing dashes';
-        const result = validateTemplate(template, settings);
+        const result = validateTemplate(template);
         expect(result.isValid).toBe(false);
         expect(result.errors).toContain('Unclosed YAML frontmatter (missing closing ---)');
     });
 
     test('should warn about invalid YAML lines', () => {
         const template = '---\ntitle: test\nthis is not yaml\n---';
-        const result = validateTemplate(template, settings);
+        const result = validateTemplate(template);
         expect(result.isValid).toBe(true);
         expect(result.warnings).toContain('Possible invalid YAML line 3: "this is not yaml"');
     });


### PR DESCRIPTION
🎯 **What:** Removed the unused `settings` parameter from `validateTemplate` in `src/template-validator.ts` and updated all call sites across the codebase.
💡 **Why:** The `settings` parameter was entirely unused within the `validateTemplate` function body, so removing it cleans up a TypeScript compiler warning and simplifies the function's signature and its usage across the plugin.
✅ **Verification:** Verified by checking types (`npm run build`) and ensuring all tests continue to pass (`npm run test`). Checked the docs and found they already had the parameter-less function signature.
✨ **Result:** Improved codebase health with no change in functional behavior.

---
*PR created automatically by Jules for task [8318285737501304493](https://jules.google.com/task/8318285737501304493) started by @frostmute*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frostmute/make-it-rain/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->