### PR TITLE
Fix folder names matching YAML null keywords losing string type in frontmatter

### DIFF
--- a/src/utils/yamlUtils.ts
+++ b/src/utils/yamlUtils.ts
@@ -74,7 +74,7 @@ export function formatYamlValue(value: unknown, indentLevel: number = 0, seen?: 
       value.includes("`") ||
       value.trim() === "" ||
       /^[0-9]/.test(value) || // Starts with number
-      /^true$|^false$|^yes$|^no$|^on$|^off$/i.test(value) // Looks like a boolean
+      /^true$|^false$|^yes$|^no$|^on$|^off$|^null$|^~$/i.test(value) // Looks like a boolean or null
     ) {
       // If the string contains newlines, use the block scalar syntax
       if (value.includes("\n")) {

--- a/src/utils/yamlUtils.ts
+++ b/src/utils/yamlUtils.ts
@@ -74,7 +74,7 @@ export function formatYamlValue(value: unknown, indentLevel: number = 0, seen?: 
       value.includes("`") ||
       value.trim() === "" ||
       /^[0-9]/.test(value) || // Starts with number
-      /^true$|^false$|^yes$|^no$|^on$|^off$|^null$|^~$/i.test(value) // Looks like a boolean or null
+      /^(?:true|false|yes|no|on|off|null|~|y|n)$/i.test(value) // Looks like a boolean or null
     ) {
       // If the string contains newlines, use the block scalar syntax
       if (value.includes("\n")) {

--- a/tests/unit/utils/yamlUtils.test.ts
+++ b/tests/unit/utils/yamlUtils.test.ts
@@ -134,6 +134,13 @@ describe('yamlUtils', () => {
                 expect(formatYamlValue('off')).toBe('"off"');
             });
 
+            it('should quote null-like strings', () => {
+                expect(formatYamlValue('null')).toBe('"null"');
+                expect(formatYamlValue('Null')).toBe('"Null"');
+                expect(formatYamlValue('NULL')).toBe('"NULL"');
+                expect(formatYamlValue('~')).toBe('"~"');
+            });
+
             it('should quote empty strings', () => {
                 const result = formatYamlValue('   ');
                 expect(result).toContain('"');


### PR DESCRIPTION
## Description
Addresses the Devin Review finding (`BUG_pr-review-job-..._0001`) from PR #65. After #65 refactored folder-note frontmatter to use `createYamlFrontmatter`/`formatYamlValue`, a regression was introduced: a collection named `null`, `Null`, `NULL`, or `~` now serializes as `title: null` (unquoted), which YAML parses as the null value instead of the string. The old inline code always wrapped the title in double quotes, so it produced `title: "null"`.

Root cause is in `formatYamlValue` (`src/utils/yamlUtils.ts:77`): the regex that forces quoting for YAML-reserved scalars only covered booleans (`true/false/yes/no/on/off`) and omitted null-like values.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues
Follow-up to #65 (merged) — fixes a Devin Review finding on that PR.

## Changes Made
- `src/utils/yamlUtils.ts`: extend the reserved-word regex to also match null-like values:
  - `/^true$|^false$|^yes$|^no$|^on$|^off$/i` → `/^true$|^false$|^yes$|^no$|^on$|^off$|^null$|^~$/i`
- `tests/unit/utils/yamlUtils.test.ts`: add a test asserting `null`, `Null`, `NULL`, and `~` are quoted.

## Testing
- [x] Unit tests added/updated
- [x] All tests passing locally

### Test Instructions
1. `npm test` — 233 tests pass (includes new null-like coverage).
2. `npm run build` — succeeds; artifacts produced.
3. `npm run scan-secrets` — clean.

## Breaking Changes
None.

## Additional Context
This fix benefits every caller of `formatYamlValue`/`createYamlFrontmatter`, not just folder notes. The Gemini Code Assist import-formatting suggestion on #65 was already applied in `main` (commit `5bb4d93`), so no further change was needed there. The two lower-confidence "additional findings" shown only in the Devin Review web app were not reproduced by a fresh re-analysis (0 bugs/0 flags) and were never posted to the PR, so only the confirmed, concrete finding above is addressed here.


Link to Devin session: https://app.devin.ai/sessions/e9665d666e3a4ffbabd93a0e04994fbb
Requested by: @frostmute
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frostmute/make-it-rain/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->