### PR TITLE
formatYamlString: serialize null/undefined as unquoted null keyword

### DIFF
--- a/src/utils/yamlUtils.ts
+++ b/src/utils/yamlUtils.ts
@@ -170,11 +170,19 @@ export function escapeYamlString(str: string): string {
  * parser (e.g. a title of `null` becoming an actual null, or `2024-01-15`
  * becoming a date).
  *
+ * An explicit `null`/`undefined` value is serialized as the unquoted `null`
+ * keyword (rather than an empty quoted string) so a genuinely absent value stays
+ * distinct from an empty string.
+ *
  * @param value - Value to serialize as a YAML string
- * @returns A quoted (or block) YAML scalar
+ * @returns A quoted (or block) YAML scalar, or `null` for null/undefined
  */
 export function formatYamlString(value: unknown): string {
-  const str = typeof value === "string" ? value : String(value ?? "");
+  if (value === null || value === undefined) {
+    return "null";
+  }
+
+  const str = typeof value === "string" ? value : String(value);
 
   if (str.includes("\n")) {
     const lines = str.split("\n");

--- a/tests/unit/utils/yamlUtils.test.ts
+++ b/tests/unit/utils/yamlUtils.test.ts
@@ -349,6 +349,11 @@ describe('yamlUtils', () => {
         it('should coerce non-string values to quoted strings', () => {
             expect(formatYamlString(2024)).toBe('"2024"');
         });
+
+        it('should serialize null/undefined as the unquoted null keyword', () => {
+            expect(formatYamlString(null)).toBe('null');
+            expect(formatYamlString(undefined)).toBe('null');
+        });
     });
 
     describe('createYamlFrontmatter', () => {


### PR DESCRIPTION
## Summary
Follow-up to review feedback on #74 (gemini-code-assist, comment 3365719336). `formatYamlString` previously coerced an explicit `null`/`undefined` to an empty quoted string `""`. Now it returns the unquoted `null` keyword, preserving the null-vs-empty-string distinction (idiomatic YAML).

```diff
 export function formatYamlString(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "null";
+  }
-  const str = typeof value === "string" ? value : String(value ?? "");
+  const str = typeof value === "string" ? value : String(value);
```

Non-null values are unaffected — they are still always quoted (or block-scalar for multi-line), so a string literally equal to `"null"`/`"~"`/a date still serializes as a quoted string. In practice the force-quoted call sites (`title`, `description`, collection fields) never pass real `null`, so this is a correctness/robustness improvement to the helper rather than a behavior change on the import path.

### Tests
- Added: `formatYamlString(null)` and `formatYamlString(undefined)` → `'null'`.

`npm test` (247 passing) and `npm run build` pass locally.

Link to Devin session: https://app.devin.ai/sessions/80f493e451204cb78d9f922efe415154
Requested by: @frostmute
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frostmute/make-it-rain/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->