### PR TITLE
Refactor template-settings UI: opt-in preview modal and per-type cards

### DIFF
--- a/src/modals.ts
+++ b/src/modals.ts
@@ -907,9 +907,14 @@ export class TemplatePreviewModal extends Modal {
         container.empty();
 
         // Tear down child components from the previous render before starting a
-        // new one so listeners/components don't leak across renders.
-        this.previewComponent.unload();
+        // new one so listeners/components don't leak across renders. Register
+        // the new one as a child of the modal (via addChild) so it is loaded —
+        // Obsidian only drives onload/onunload on registered children, which is
+        // what makes embeds/nested renders created during markdown rendering
+        // initialize correctly and get torn down when the modal closes.
+        this.removeChild(this.previewComponent);
         this.previewComponent = new Component();
+        this.addChild(this.previewComponent);
 
         try {
             const sampleData = SAMPLE_RAINDROPS[this.selectedSampleType];
@@ -922,13 +927,24 @@ export class TemplatePreviewModal extends Modal {
             }
             const ctx = this.buildContext(sampleData);
             const rendered = this.plugin.renderTemplate(this.template, ctx);
-            void MarkdownRenderer.render(this.app, rendered, container, '', this.previewComponent).then(() => {
-                // A newer render superseded this one (rapid dropdown switching);
-                // drop its output to avoid mixed/duplicated preview content.
-                if (token !== this.renderToken) {
+            void MarkdownRenderer.render(this.app, rendered, container, '', this.previewComponent)
+                .then(() => {
+                    // A newer render superseded this one (rapid dropdown switching);
+                    // drop its output to avoid mixed/duplicated preview content.
+                    if (token !== this.renderToken) {
+                        container.empty();
+                    }
+                })
+                .catch((e) => {
+                    // Only surface the failure if this render is still the current
+                    // one — a stale render's rejection should be silently dropped.
+                    if (token !== this.renderToken) return;
                     container.empty();
-                }
-            });
+                    container.createDiv({
+                        text: `Preview error: ${e instanceof Error ? e.message : String(e)}`,
+                        cls: 'make-it-rain-preview-error'
+                    });
+                });
         } catch (e) {
             container.createDiv({
                 text: `Preview error: ${e instanceof Error ? e.message : String(e)}`,
@@ -940,7 +956,8 @@ export class TemplatePreviewModal extends Modal {
     onClose() {
         const { contentEl } = this;
         contentEl.empty();
-        this.previewComponent.unload();
+        // previewComponent is registered via addChild(), so Obsidian unloads it
+        // automatically when the modal closes — no manual unload needed here.
     }
 }
 

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -1,14 +1,15 @@
-import { App, Modal, Setting, TextComponent, ButtonComponent, Notice, ToggleComponent, DropdownComponent } from 'obsidian';
+import { App, Modal, Setting, TextComponent, ButtonComponent, Notice, ToggleComponent, DropdownComponent, MarkdownRenderer, Component } from 'obsidian';
 import type RaindropToObsidian from './main';
-import { 
+import {
     IRaindropToObsidian,
-    RaindropCollection, 
-    RaindropType, 
-    TagMatchTypes, 
-    RaindropTypes, 
+    RaindropCollection,
+    RaindropType,
+    TagMatchTypes,
+    RaindropTypes,
     ModalFetchOptions,
     AggregateHighlightsOptions
 } from './types';
+import { SAMPLE_RAINDROPS } from './utils/sampleData';
 
 /**
  * Modal for fetching raindrops with filters
@@ -821,6 +822,109 @@ export class VariableBrowserModal extends Modal {
             item.createEl('code', { text: `{{${v.name}}}` });
             item.createSpan({ text: ` - ${v.desc}`, cls: 'variable-description' });
         }
+    }
+}
+
+/**
+ * Template preview modal. Opt-in — replaces the always-on side-by-side
+ * preview that lived inside the settings panel. Previews are a deliberate
+ * action: click Preview, see the rendered note, close.
+ *
+ * If `lockedType` is set, the sample-type dropdown is hidden and the
+ * preview is always rendered against that type. Useful for content-type
+ * overrides where the template is type-specific.
+ */
+export class TemplatePreviewModal extends Modal {
+    plugin: RaindropToObsidian;
+    template: string;
+    buildContext: (sample: import('./utils/sampleData').SampleRaindrop) => import('./types').TemplateData;
+    lockedType?: RaindropType;
+    selectedSampleType: RaindropType;
+    private previewComponent: Component = new Component();
+
+    constructor(
+        app: App,
+        plugin: RaindropToObsidian,
+        template: string,
+        buildContext: (sample: import('./utils/sampleData').SampleRaindrop) => import('./types').TemplateData,
+        lockedType?: RaindropType
+    ) {
+        super(app);
+        this.plugin = plugin;
+        this.template = template;
+        this.buildContext = buildContext;
+        this.lockedType = lockedType;
+        this.selectedSampleType = lockedType ?? RaindropTypes.LINK;
+    }
+
+    onOpen() {
+        const { contentEl } = this;
+        contentEl.empty();
+        contentEl.addClass('make-it-rain-modal');
+        contentEl.addClass('make-it-rain-template-preview-modal');
+
+        const header = contentEl.createDiv({ cls: 'make-it-rain-modal-header' });
+        header.createEl('h2', { text: 'Template preview' });
+        header.createEl('p', {
+            text: this.lockedType
+                ? `Rendered against a sample ${this.lockedType} raindrop.`
+                : 'Select a sample type below to see how this template renders.',
+            cls: 'setting-item-description'
+        });
+
+        const controls = contentEl.createDiv({ cls: 'make-it-rain-template-preview-controls' });
+        const previewArea = contentEl.createDiv({ cls: 'make-it-rain-template-preview-content' });
+
+        if (!this.lockedType) {
+            const selectorSetting = new Setting(controls)
+                .setName('Sample type')
+                .addDropdown((dropdown) => {
+                    Object.values(RaindropTypes).forEach(t => {
+                        dropdown.addOption(t, t.charAt(0).toUpperCase() + t.slice(1));
+                    });
+                    dropdown.setValue(this.selectedSampleType)
+                        .onChange((value) => {
+                            this.selectedSampleType = value as RaindropType;
+                            this.render(previewArea);
+                        });
+                });
+            selectorSetting.controlEl.addClass('make-it-rain-template-preview-selector');
+        }
+
+        this.render(previewArea);
+
+        const footer = contentEl.createDiv({ cls: 'make-it-rain-button-container' });
+        new ButtonComponent(footer)
+            .setButtonText('Close')
+            .onClick(() => this.close());
+    }
+
+    private render(container: HTMLElement) {
+        container.empty();
+        try {
+            const sampleData = SAMPLE_RAINDROPS[this.selectedSampleType];
+            if (!sampleData) {
+                container.createDiv({
+                    text: `No sample data available for type "${this.selectedSampleType}".`,
+                    cls: 'make-it-rain-preview-error'
+                });
+                return;
+            }
+            const ctx = this.buildContext(sampleData);
+            const rendered = this.plugin.renderTemplate(this.template, ctx);
+            void MarkdownRenderer.render(this.app, rendered, container, '', this.previewComponent);
+        } catch (e) {
+            container.createDiv({
+                text: `Preview error: ${e instanceof Error ? e.message : String(e)}`,
+                cls: 'make-it-rain-preview-error'
+            });
+        }
+    }
+
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+        this.previewComponent.unload();
     }
 }
 

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -841,6 +841,9 @@ export class TemplatePreviewModal extends Modal {
     lockedType?: RaindropType;
     selectedSampleType: RaindropType;
     private previewComponent: Component = new Component();
+    // Incremented on every render so a slow async render started before a
+    // rapid sample-type switch can detect it is stale and bail out.
+    private renderToken = 0;
 
     constructor(
         app: App,
@@ -900,7 +903,14 @@ export class TemplatePreviewModal extends Modal {
     }
 
     private render(container: HTMLElement) {
+        const token = ++this.renderToken;
         container.empty();
+
+        // Tear down child components from the previous render before starting a
+        // new one so listeners/components don't leak across renders.
+        this.previewComponent.unload();
+        this.previewComponent = new Component();
+
         try {
             const sampleData = SAMPLE_RAINDROPS[this.selectedSampleType];
             if (!sampleData) {
@@ -912,7 +922,13 @@ export class TemplatePreviewModal extends Modal {
             }
             const ctx = this.buildContext(sampleData);
             const rendered = this.plugin.renderTemplate(this.template, ctx);
-            void MarkdownRenderer.render(this.app, rendered, container, '', this.previewComponent);
+            void MarkdownRenderer.render(this.app, rendered, container, '', this.previewComponent).then(() => {
+                // A newer render superseded this one (rapid dropdown switching);
+                // drop its output to avoid mixed/duplicated preview content.
+                if (token !== this.renderToken) {
+                    container.empty();
+                }
+            });
         } catch (e) {
             container.createDiv({
                 text: `Preview error: ${e instanceof Error ? e.message : String(e)}`,

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -906,15 +906,15 @@ export class TemplatePreviewModal extends Modal {
         const token = ++this.renderToken;
         container.empty();
 
-        // Tear down child components from the previous render before starting a
-        // new one so listeners/components don't leak across renders. Register
-        // the new one as a child of the modal (via addChild) so it is loaded —
-        // Obsidian only drives onload/onunload on registered children, which is
-        // what makes embeds/nested renders created during markdown rendering
-        // initialize correctly and get torn down when the modal closes.
-        this.removeChild(this.previewComponent);
+        // Tear down the previous render's component before starting a new one so
+        // listeners/components don't leak across renders, then load() the fresh
+        // one. Loading drives the onload lifecycle, which is what makes embeds
+        // and other nested renders created during markdown rendering initialize
+        // correctly. (Modal's typings don't expose addChild/removeChild, so we
+        // manage the component's lifecycle directly.)
+        this.previewComponent.unload();
         this.previewComponent = new Component();
-        this.addChild(this.previewComponent);
+        this.previewComponent.load();
 
         try {
             const sampleData = SAMPLE_RAINDROPS[this.selectedSampleType];
@@ -956,8 +956,9 @@ export class TemplatePreviewModal extends Modal {
     onClose() {
         const { contentEl } = this;
         contentEl.empty();
-        // previewComponent is registered via addChild(), so Obsidian unloads it
-        // automatically when the modal closes — no manual unload needed here.
+        // We manage previewComponent's lifecycle manually, so unload it here to
+        // tear down any child renders created during the last preview.
+        this.previewComponent.unload();
     }
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,10 +1,10 @@
-import { App, Component, PluginSettingTab, Setting, TextComponent, ButtonComponent, Notice, request, ToggleComponent, TextAreaComponent, MarkdownRenderer, DropdownComponent } from 'obsidian';
+import { App, PluginSettingTab, Setting, TextComponent, ButtonComponent, Notice, request, ToggleComponent, TextAreaComponent, DropdownComponent } from 'obsidian';
 import type RaindropToObsidian from './main';
 import { RaindropTypes, RaindropType } from './types';
 import { MakeItRainSettings, TemplateData } from './types';
-import { VariableBrowserModal, TemplateSharingModal } from './modals';
+import { VariableBrowserModal, TemplateSharingModal, TemplatePreviewModal } from './modals';
 import { validateTemplate, ValidationResult } from './template-validator';
-import { SAMPLE_RAINDROPS } from './utils/sampleData';
+import { SampleRaindrop } from './utils/sampleData';
 
 export const DEFAULT_SETTINGS: MakeItRainSettings = {
     apiToken: '',
@@ -318,13 +318,6 @@ tags:
 
 export class RaindropToObsidianSettingTab extends PluginSettingTab {
     plugin: RaindropToObsidian;
-    selectedTemplateType: string = 'link';
-    // Tab-scoped component so MarkdownRenderer.render doesn't anchor
-    // child render lifecycles to the long-lived plugin instance.
-    private previewComponent: Component = new Component();
-    // Per-preview sample type selection, keyed by preview container so that
-    // each preview panel maintains its own independent dropdown state.
-    private previewSampleTypes: WeakMap<HTMLElement, RaindropType> = new WeakMap();
 
     constructor(app: App, plugin: RaindropToObsidian) {
         super(app, plugin);
@@ -341,69 +334,46 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
         return [];
     }
 
-    private renderTemplatePreview(container: HTMLElement, template: string, lockedSampleType?: RaindropType) {
-        // Store the latest template on the container so the dropdown's onChange
-        // handler (created once) always re-renders with the current value.
-        container.dataset.template = template;
+    /**
+     * Build the context object used for previews. Kept here so both the
+     * default-template preview and the content-type previews render
+     * identically.
+     */
+    private buildPreviewContext(sampleData: SampleRaindrop): TemplateData {
+        return {
+            ...sampleData,
+            bannerFieldName: this.plugin.settings.bannerFieldName,
+            url: sampleData.link,
+            domain: (() => { try { return new URL(sampleData.link).hostname; } catch { return ''; } })(),
+            renderedType: (() => {
+                const types: Record<string, string> = {
+                    link: 'web link', article: 'article', image: 'image',
+                    video: 'video', doc: 'document', audio: 'audio', book: 'book'
+                };
+                return types[sampleData.type] || sampleData.type;
+            })(),
+            formattedCreatedDate: new Date(sampleData.created).toLocaleDateString(),
+            formattedUpdatedDate: new Date(sampleData.lastupdate).toLocaleDateString(),
+            formattedTags: sampleData.tags.map(t => `#${t}`).join(' ')
+        } as unknown as TemplateData;
+    }
 
-        // Each preview keeps its own sample type so switching the dropdown in
-        // one panel doesn't leak into others. When a sample type is locked (e.g.
-        // for content-type overrides) the dropdown is omitted and that type is
-        // always used.
-        let selectedSampleType = lockedSampleType ?? this.previewSampleTypes.get(container);
-        if (!selectedSampleType) {
-            selectedSampleType = RaindropTypes.LINK;
-            this.previewSampleTypes.set(container, selectedSampleType);
-        }
-
-        let header = container.querySelector<HTMLElement>('.make-it-rain-preview-header');
-        let previewContent = container.querySelector<HTMLElement>('.make-it-rain-preview-content');
-
-        if (!header) {
-            header = container.createDiv({ cls: 'make-it-rain-preview-header' });
-            header.createSpan({ text: 'Live Preview', cls: 'make-it-rain-preview-title' });
-
-            if (!lockedSampleType) {
-                const sampleSelector = new DropdownComponent(header);
-                Object.values(RaindropTypes).forEach(t => {
-                    sampleSelector.addOption(t, t.charAt(0).toUpperCase() + t.slice(1));
-                });
-                sampleSelector.setValue(selectedSampleType)
-                    .onChange((value) => {
-                        this.previewSampleTypes.set(container, value as RaindropType);
-                        this.renderTemplatePreview(container, container.dataset.template || '');
-                    });
-            }
-
-            previewContent = container.createDiv({ cls: 'make-it-rain-preview-content' });
-        }
-
-        if (!previewContent) return;
-        previewContent.empty();
-
+    /**
+     * Open the opt-in template preview modal. Replaces the always-on
+     * side-by-side preview that ate half the editor width — previews are
+     * now a deliberate action, not ambient noise.
+     */
+    private openTemplatePreview(template: string, lockedType?: RaindropType) {
         try {
-            const sampleData = SAMPLE_RAINDROPS[selectedSampleType];
-            const dataForRender = {
-                ...sampleData,
-                bannerFieldName: this.plugin.settings.bannerFieldName,
-                url: sampleData.link,
-                domain: new URL(sampleData.link).hostname,
-                renderedType: (() => { const types: Record<string, string> = { link: 'web link', article: 'article', image: 'image', video: 'video', doc: 'document', audio: 'audio', book: 'book' }; return types[sampleData.type] || sampleData.type; })(),
-                formattedCreatedDate: new Date(sampleData.created).toLocaleDateString(),
-                formattedUpdatedDate: new Date(sampleData.lastupdate).toLocaleDateString(),
-                formattedTags: sampleData.tags.map(t => `#${t}`).join(' ')
-            } as unknown as TemplateData;
-
-            const rendered = this.plugin.renderTemplate(template, dataForRender);
-            
-            // Render as Markdown — use a tab-scoped Component so we don't leak
-            // child components through the plugin's long-lived lifecycle.
-            void MarkdownRenderer.render(this.app, rendered, previewContent, '', this.previewComponent);
+            new TemplatePreviewModal(
+                this.app,
+                this.plugin,
+                template,
+                this.buildPreviewContext,
+                lockedType
+            ).open();
         } catch (e) {
-            previewContent.createDiv({
-                text: `Preview error: ${e instanceof Error ? e.message : String(e)}`,
-                cls: 'make-it-rain-preview-error'
-            });
+            new Notice(`Preview failed: ${e instanceof Error ? e.message : String(e)}`, 7000);
         }
     }
 
@@ -623,13 +593,15 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
             });
 
         // --- 5. Template Engine ---
-        const templateSection = containerEl.createEl('details', { cls: 'make-it-rain-settings-section make-it-rain-advanced-options' });
+        // Section is OPEN by default — this is where 90% of users actually
+        // configure things. Wrapped in <details> so the rare non-template
+        // user can collapse it.
+        const templateSection = containerEl.createEl('details', { cls: 'make-it-rain-settings-section make-it-rain-template-section', attr: { open: '' } });
         templateSection.createEl('summary', { text: 'Template Engine', cls: 'make-it-rain-section-summary' });
         const templateContent = templateSection.createDiv({ cls: 'make-it-rain-section-content' });
 
-        const templateWrapper = templateContent.createDiv();
-        templateWrapper.style.display = this.plugin.settings.isTemplateSystemEnabled ? 'block' : 'none';
-
+        // Master enable toggle — hides the whole editor surface when off,
+        // so power users can disable templates without losing the toggle.
         new Setting(templateContent)
             .setName('Enable template system')
             .setDesc('Use custom Handlebars templates for formatting imported notes instead of the basic fallback structure.')
@@ -638,35 +610,27 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                     .onChange(async (value: boolean) => {
                         this.plugin.settings.isTemplateSystemEnabled = value;
                         await this.plugin.saveSettings();
-                        templateWrapper.style.display = value ? 'block' : 'none';
+                        templateBody.style.display = value ? 'block' : 'none';
                     });
             });
 
-        new Setting(templateWrapper)
-            .setName('Template Reference')
-            .setDesc('View all available variables, properties, and formatting helpers you can inject into your templates.')
-            .addButton((button: ButtonComponent) => {
-                button
-                    .setButtonText("Browse variables")
-                    .setIcon("search")
-                    .onClick(() => {
-                        new VariableBrowserModal(this.app).open();
-                    });
-            });
+        const templateBody = templateContent.createDiv();
+        templateBody.style.display = this.plugin.settings.isTemplateSystemEnabled ? 'block' : 'none';
 
-        new Setting(templateWrapper)
-            .setName('Import Template')
-            .setDesc('Import a template shared by the community.')
+        // Helper links row — kept compact, single setting row.
+        new Setting(templateBody)
+            .setName('Reference & sharing')
+            .setDesc('Browse variables, or import a template shared by the community.')
             .addButton((button: ButtonComponent) => {
-                button
-                    .setButtonText("Import template")
-                    .setIcon("import")
+                button.setButtonText('Browse variables').setIcon('search')
+                    .onClick(() => { new VariableBrowserModal(this.app).open(); });
+            })
+            .addButton((button: ButtonComponent) => {
+                button.setButtonText('Import template').setIcon('import')
                     .onClick(() => {
                         new TemplateSharingModal(this.app, this.plugin, 'import', '', async (jsonStr) => {
                             const imported = this.plugin.importTemplate(jsonStr);
-                            if (!imported) {
-                                return false;
-                            }
+                            if (!imported) return false;
                             let targetName = imported.name;
                             if (Object.prototype.hasOwnProperty.call(this.plugin.settings.namedTemplates, targetName)) {
                                 targetName = `${targetName}-imported-${Date.now()}`;
@@ -680,44 +644,21 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                     });
             });
 
-        // Reusable Parts (Named Templates)
-        new Setting(templateWrapper).setName('Reusable Partials').setHeading();
-        const namedDesc = templateWrapper.createEl('p', { cls: 'setting-item-description' });
-        namedDesc.appendText('Create reusable snippets that can be included in other templates using {{#include "name"}} or extended using {{#extends "name"}}.');
+        // ── Default Global Template ─────────────────────────────────────
+        new Setting(templateBody).setName('Default template').setHeading();
+        templateBody.createEl('p', {
+            text: 'Used when no content-type override below is enabled.',
+            cls: 'setting-item-description'
+        });
 
-        const namedTemplatesContainer = templateWrapper.createDiv('make-it-rain-named-templates-container');
-        this.renderNamedTemplates(namedTemplatesContainer);
-
-        new Setting(templateWrapper)
-            .addButton((button: ButtonComponent) => {
-                button.setButtonText("+ Add new partial")
-                    .setCta()
-                    .onClick(async () => {
-                        const name = "new-partial-" + Date.now();
-                        this.plugin.settings.namedTemplates[name] = "";
-                        await this.plugin.saveSettings();
-                        this.renderNamedTemplates(namedTemplatesContainer);
-                    });
-            });
-
-        // Default Template
-        new Setting(templateWrapper).setName('Default Global Template').setHeading();
-        
-        const defaultTmplSideBySide = templateWrapper.createDiv({ cls: 'make-it-rain-side-by-side' });
-        const defaultEditorArea = defaultTmplSideBySide.createDiv({ cls: 'make-it-rain-editor-area' });
-        const defaultPreviewArea = defaultTmplSideBySide.createDiv({ cls: 'make-it-rain-preview-area' });
-
-        new Setting(defaultEditorArea)
-            .setDesc('This template is used if no content-type specific template is active below.')
+        new Setting(templateBody)
             .setClass('setting-item-stacked')
             .addTextArea((text: TextAreaComponent) => {
-                const validationContainer = defaultEditorArea.createDiv('make-it-rain-validation-container');
+                const validationContainer = templateBody.createDiv('make-it-rain-validation-container');
                 const updateValidation = (val: string) => {
                     const result = validateTemplate(val, this.plugin.settings);
                     this.renderValidationResult(validationContainer, result);
-                    this.renderTemplatePreview(defaultPreviewArea, val);
                 };
-
                 text.setPlaceholder('Enter your default handlebars template here.')
                     .setValue(this.plugin.settings.defaultTemplate)
                     .onChange(async (value: string) => {
@@ -725,142 +666,88 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                         await this.plugin.saveSettings();
                         updateValidation(value);
                     });
-                text.inputEl.rows = 8;
+                text.inputEl.rows = 10;
                 text.inputEl.addClass('make-it-rain-full-width');
                 text.inputEl.addClass('make-it-rain-monospace');
                 updateValidation(this.plugin.settings.defaultTemplate);
             })
             .addButton((button: ButtonComponent) => {
-                button
-                    .setButtonText("Reset default")
-                    .setIcon("undo")
-                    .setTooltip("Reset this template to its original default value")
-                    .onClick(async () => {
-                        this.plugin.settings.defaultTemplate = DEFAULT_SETTINGS.defaultTemplate;
-                        await this.plugin.saveSettings();
-                        this.update(); // Re-render everything to update preview
-                        new Notice("Default template has been reset.");
+                button.setButtonText('Preview').setIcon('eye')
+                    .setTooltip('Render this template against a sample raindrop')
+                    .onClick(() => {
+                        this.openTemplatePreview(this.plugin.settings.defaultTemplate);
                     });
             })
             .addButton((button: ButtonComponent) => {
-                button
-                    .setButtonText("Export")
-                    .setIcon("export")
-                    .setTooltip("Export this template")
+                button.setButtonText('Reset').setIcon('undo')
+                    .setTooltip('Reset this template to its original default value')
+                    .onClick(async () => {
+                        this.plugin.settings.defaultTemplate = DEFAULT_SETTINGS.defaultTemplate;
+                        await this.plugin.saveSettings();
+                        this.update();
+                        new Notice('Default template has been reset.');
+                    });
+            })
+            .addButton((button: ButtonComponent) => {
+                button.setButtonText('Export').setIcon('export')
+                    .setTooltip('Export this template')
                     .onClick(() => {
-                        const jsonStr = this.plugin.exportTemplate('default', this.plugin.settings.defaultTemplate, 'Default Global Template');
+                        const jsonStr = this.plugin.exportTemplate(
+                            'default',
+                            this.plugin.settings.defaultTemplate,
+                            'Default Global Template'
+                        );
                         new TemplateSharingModal(this.app, this.plugin, 'export', jsonStr).open();
                     });
             });
 
-        // Content-Type Editor
-        new Setting(templateWrapper).setName('Content-Type Overrides').setHeading();
-        const contentTypeDesc = templateWrapper.createEl('p', { cls: 'setting-item-description' });
-        contentTypeDesc.appendText('Define specific layout overrides for different raindrop types (e.g. extending the base template to show video timestamps vs article content).');
+        // ── Content-Type Overrides ──────────────────────────────────────
+        // The big change: every type gets its own visible, labeled block.
+        // No dropdown picker. Toggle hides/shows that type's textarea inline.
+        new Setting(templateBody).setName('Content-type overrides').setHeading();
+        templateBody.createEl('p', {
+            text: 'Define a custom template for each raindrop type. Toggle an override on to replace the default for that type only.',
+            cls: 'setting-item-description'
+        });
 
-        const editorCard = templateWrapper.createDiv({ cls: 'make-it-rain-settings-card' });
-        
-        const typeSelectorDiv = editorCard.createDiv({ cls: 'make-it-rain-type-selector' });
-        const sideBySideDiv = editorCard.createDiv({ cls: 'make-it-rain-side-by-side' });
-        const editorAreaDiv = sideBySideDiv.createDiv({ cls: 'make-it-rain-editor-area' });
-        const previewAreaDiv = sideBySideDiv.createDiv({ cls: 'make-it-rain-preview-area' });
-        
-        const renderEditor = () => {
-            editorAreaDiv.empty();
-            previewAreaDiv.empty();
-            
-            const typeStr = this.selectedTemplateType;
-            // Map API type to internal property name (document -> doc to avoid global conflicts)
-            const typeKey = (typeStr === 'document' ? 'doc' : typeStr) as keyof typeof this.plugin.settings.contentTypeTemplates;
-            const isEnabled = this.plugin.settings.contentTypeTemplateToggles[typeKey];
-            
-            new Setting(editorAreaDiv)
-                .setName('Enable override')
-                .setDesc('Use a custom template for ' + typeStr + ' items instead of the global default.')
-                .addToggle((toggle: ToggleComponent) => {
-                    toggle
-                        .setValue(isEnabled)
-                        .onChange(async (value: boolean) => {
-                            this.plugin.settings.contentTypeTemplateToggles[typeKey] = value;
-                            await this.plugin.saveSettings();
-                            renderEditor();
-                        });
-                });
+        // Render in stable, predictable order (not Object.keys order).
+        // RaindropTypes values use 'document' but the settings key is 'doc'
+        // (the 'doc' avoids a global Document clash in templates). Map here.
+        type ContentTypeKey = keyof MakeItRainSettings['contentTypeTemplates'];
+        const orderedTypes: Array<{ typeStr: RaindropType; typeKey: ContentTypeKey }> = [
+            { typeStr: RaindropTypes.LINK, typeKey: 'link' },
+            { typeStr: RaindropTypes.ARTICLE, typeKey: 'article' },
+            { typeStr: RaindropTypes.IMAGE, typeKey: 'image' },
+            { typeStr: RaindropTypes.VIDEO, typeKey: 'video' },
+            { typeStr: RaindropTypes.DOCUMENT, typeKey: 'doc' },
+            { typeStr: RaindropTypes.AUDIO, typeKey: 'audio' },
+            { typeStr: RaindropTypes.BOOK, typeKey: 'book' }
+        ];
 
-            if (isEnabled) {
-                new Setting(editorAreaDiv)
-                    .setDesc('Template for ' + typeStr + ' content.')
-                    .setClass('setting-item-stacked')
-                    .addTextArea((text: TextAreaComponent) => {
-                        const validationContainer = editorAreaDiv.createDiv('make-it-rain-validation-container');
-                        const updateValidation = (val: string) => {
-                            const result = validateTemplate(val, this.plugin.settings);
-                            this.renderValidationResult(validationContainer, result);
-                            this.renderTemplatePreview(previewAreaDiv, val, this.selectedTemplateType as RaindropType);
-                        };
+        for (const entry of orderedTypes) {
+            this.renderContentTypeCard(templateBody, entry.typeStr, entry.typeKey);
+        }
 
-                        text.setPlaceholder('Enter template for ' + typeStr + ' items...')
-                            .setValue(this.plugin.settings.contentTypeTemplates[typeKey] || '')
-                            .onChange(async (value: string) => {
-                                this.plugin.settings.contentTypeTemplates[typeKey] = value;
-                                await this.plugin.saveSettings();
-                                updateValidation(value);
-                            });
-                        text.inputEl.rows = 12;
-                        text.inputEl.addClass('make-it-rain-full-width');
-                        text.inputEl.addClass('make-it-rain-monospace');
-                        updateValidation(this.plugin.settings.contentTypeTemplates[typeKey] || '');
-                    })
-                    .addButton((button: ButtonComponent) => {
-                        button
-                            .setButtonText("Reset")
-                            .setIcon("undo")
-                            .setTooltip('Reset ' + typeStr + ' template to its original default')
-                            .onClick(async () => {
-                                if (DEFAULT_SETTINGS.contentTypeTemplates[typeKey]) {
-                                    this.plugin.settings.contentTypeTemplates[typeKey] = DEFAULT_SETTINGS.contentTypeTemplates[typeKey];
-                                    await this.plugin.saveSettings();
-                                    renderEditor();
-                                    new Notice(typeStr.charAt(0).toUpperCase() + typeStr.slice(1) + ' template has been reset.');
-                                } else {
-                                    new Notice('Error: Default template for ' + typeStr + ' not found.', 7000);
-                                }
-                            });
-                    })
-                    .addButton((button: ButtonComponent) => {
-                        button
-                            .setButtonText("Export")
-                            .setIcon("export")
-                            .setTooltip('Export ' + typeStr + ' template')
-                            .onClick(() => {
-                                const jsonStr = this.plugin.exportTemplate(`content-type-${typeStr}`, this.plugin.settings.contentTypeTemplates[typeKey], `Content-Type Template for ${typeStr}`);
-                                new TemplateSharingModal(this.app, this.plugin, 'export', jsonStr).open();
-                            });
-                    });
-            } else {
-                previewAreaDiv.createDiv({
-                    text: 'Enable the override to see a live preview of this content-type template.',
-                    cls: 'setting-item-description'
-                });
-            }
-        };
+        // ── Reusable Partials (Named Templates) ────────────────────────
+        new Setting(templateBody).setName('Reusable partials').setHeading();
+        templateBody.createEl('p', {
+            text: 'Reusable snippets. Include via {{#include "name"}} or extend via {{#extends "name"}}.',
+            cls: 'setting-item-description'
+        });
 
-        new Setting(typeSelectorDiv)
-            .setName('Select content type')
-            .setDesc('Choose which template to customize.')
-            .addDropdown((dropdown) => {
-                const contentTypes = Object.keys(RaindropTypes).map(key => RaindropTypes[key as keyof typeof RaindropTypes]);
-                contentTypes.forEach(type => {
-                    dropdown.addOption(type, type.charAt(0).toUpperCase() + type.slice(1));
-                });
-                dropdown.setValue(this.selectedTemplateType)
-                    .onChange((value) => {
-                        this.selectedTemplateType = value;
-                        renderEditor();
+        const namedTemplatesContainer = templateBody.createDiv('make-it-rain-named-templates-container');
+        this.renderNamedTemplates(namedTemplatesContainer);
+
+        new Setting(templateBody)
+            .addButton((button: ButtonComponent) => {
+                button.setButtonText('+ Add new partial').setCta()
+                    .onClick(async () => {
+                        const name = 'new-partial-' + Date.now();
+                        this.plugin.settings.namedTemplates[name] = '';
+                        await this.plugin.saveSettings();
+                        this.renderNamedTemplates(namedTemplatesContainer);
                     });
             });
-
-        renderEditor();
 
         // --- Footer Section ---
         containerEl.createEl('hr');
@@ -939,6 +826,91 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
         }
     }
 
+    /**
+     * Render one content-type card into the templates section. Extracted
+     * from update() so closures bind to `this` naturally.
+     */
+    private renderContentTypeCard(
+        parent: HTMLElement,
+        typeStr: RaindropType,
+        typeKey: keyof MakeItRainSettings['contentTypeTemplates']
+    ) {
+        const toggles = this.plugin.settings.contentTypeTemplateToggles;
+        const templates = this.plugin.settings.contentTypeTemplates;
+
+        const card = parent.createDiv({ cls: 'make-it-rain-type-card' });
+
+        new Setting(card)
+            .setName(`${typeStr.charAt(0).toUpperCase() + typeStr.slice(1)} items`)
+            .setDesc('Use a custom template for ' + typeStr + ' items instead of the global default.')
+            .addToggle((toggle: ToggleComponent) => {
+                toggle.setValue(toggles[typeKey])
+                    .onChange(async (value: boolean) => {
+                        toggles[typeKey] = value;
+                        await this.plugin.saveSettings();
+                        bodyEl.style.display = value ? 'block' : 'none';
+                    });
+            });
+
+        const bodyEl = card.createDiv({ cls: 'make-it-rain-type-card-body' });
+        bodyEl.style.display = toggles[typeKey] ? 'block' : 'none';
+
+        new Setting(bodyEl)
+            .setClass('setting-item-stacked')
+            .addTextArea((text: TextAreaComponent) => {
+                const validationContainer = bodyEl.createDiv('make-it-rain-validation-container');
+                const updateValidation = (val: string) => {
+                    const result = validateTemplate(val, this.plugin.settings);
+                    this.renderValidationResult(validationContainer, result);
+                };
+                text.setPlaceholder('Enter template for ' + typeStr + ' items...')
+                    .setValue(templates[typeKey] || '')
+                    .onChange(async (value: string) => {
+                        templates[typeKey] = value;
+                        await this.plugin.saveSettings();
+                        updateValidation(value);
+                    });
+                text.inputEl.rows = 8;
+                text.inputEl.addClass('make-it-rain-full-width');
+                text.inputEl.addClass('make-it-rain-monospace');
+                updateValidation(templates[typeKey] || '');
+            })
+            .addButton((button: ButtonComponent) => {
+                button.setButtonText('Preview').setIcon('eye')
+                    .setTooltip('Render this template against a sample ' + typeStr + ' raindrop')
+                    .onClick(() => {
+                        this.openTemplatePreview(templates[typeKey] || '', typeStr);
+                    });
+            })
+            .addButton((button: ButtonComponent) => {
+                button.setButtonText('Reset').setIcon('undo')
+                    .setTooltip('Reset ' + typeStr + ' template to its original default')
+                    .onClick(async () => {
+                        if (DEFAULT_SETTINGS.contentTypeTemplates[typeKey]) {
+                            templates[typeKey] = DEFAULT_SETTINGS.contentTypeTemplates[typeKey];
+                            await this.plugin.saveSettings();
+                            this.update();
+                            new Notice(typeStr.charAt(0).toUpperCase() + typeStr.slice(1) +
+                                ' template has been reset.');
+                        } else {
+                            new Notice('Error: Default template for ' + typeStr + ' not found.', 7000);
+                        }
+                    });
+            })
+            .addButton((button: ButtonComponent) => {
+                button.setButtonText('Export').setIcon('export')
+                    .setTooltip('Export ' + typeStr + ' template')
+                    .onClick(() => {
+                        const jsonStr = this.plugin.exportTemplate(
+                            `content-type-${typeStr}`,
+                            templates[typeKey],
+                            `Content-Type Template for ${typeStr}`
+                        );
+                        new TemplateSharingModal(this.app, this.plugin, 'export', jsonStr).open();
+                    });
+            });
+    }
+
     private renderValidationResult(container: HTMLElement, result: ValidationResult) {
         container.empty();
         if (result.errors.length === 0 && result.warnings.length === 0) {
@@ -965,9 +937,10 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
 
         for (const name of templateNames) {
             const templateDiv = container.createDiv('make-it-rain-named-template-item');
-            
+
+            // Header row: rename + actions
             new Setting(templateDiv)
-                .setName(`Template: ${name}`)
+                .setName(`Partial: ${name}`)
                 .addText((text) => {
                     text.setValue(name)
                         .setPlaceholder('Template name')
@@ -981,46 +954,45 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                             delete namedTemplates[name];
                             namedTemplates[newName] = content;
                             await this.plugin.saveSettings();
-                            
-                            // Clear and re-render just the named templates container
                             container.empty();
                             this.renderNamedTemplates(container);
                         });
                 })
                 .addButton((button) => {
-                    button.setIcon('export')
-                        .setTooltip('Export template')
+                    button.setIcon('eye').setTooltip('Preview partial')
                         .onClick(() => {
-                            const jsonStr = this.plugin.exportTemplate(`partial-${name}`, namedTemplates[name], `Named Partial Template: ${name}`);
+                            this.openTemplatePreview(namedTemplates[name] || '');
+                        });
+                })
+                .addButton((button) => {
+                    button.setIcon('export').setTooltip('Export template')
+                        .onClick(() => {
+                            const jsonStr = this.plugin.exportTemplate(
+                                `partial-${name}`,
+                                namedTemplates[name],
+                                `Named Partial Template: ${name}`
+                            );
                             new TemplateSharingModal(this.app, this.plugin, 'export', jsonStr).open();
                         });
                 })
                 .addButton((button) => {
-                    button.setIcon('trash')
-                        .setDestructive()
-                        .setTooltip('Delete template')
+                    button.setIcon('trash').setDestructive().setTooltip('Delete template')
                         .onClick(async () => {
                             delete namedTemplates[name];
                             await this.plugin.saveSettings();
-                            
-                            // Clear and re-render just the named templates container
                             container.empty();
                             this.renderNamedTemplates(container);
                         });
                 });
 
-            const sideBySide = templateDiv.createDiv({ cls: 'make-it-rain-side-by-side' });
-            const editorArea = sideBySide.createDiv({ cls: 'make-it-rain-editor-area' });
-            const previewArea = sideBySide.createDiv({ cls: 'make-it-rain-preview-area' });
-
-            new Setting(editorArea)
+            // Body: full-width textarea + inline validation. No side-by-side.
+            new Setting(templateDiv)
                 .setClass('setting-item-stacked')
                 .addTextArea((text) => {
-                    const validationContainer = editorArea.createDiv('make-it-rain-validation-container');
+                    const validationContainer = templateDiv.createDiv('make-it-rain-validation-container');
                     const updateValidation = (val: string) => {
                         const result = validateTemplate(val, this.plugin.settings);
                         this.renderValidationResult(validationContainer, result);
-                        this.renderTemplatePreview(previewArea, val);
                     };
 
                     text.setValue(namedTemplates[name])
@@ -1035,7 +1007,7 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                     text.inputEl.addClass('make-it-rain-monospace');
                     updateValidation(namedTemplates[name]);
                 });
-            
+
             container.createEl('hr');
         }
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -369,7 +369,7 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                 this.app,
                 this.plugin,
                 template,
-                this.buildPreviewContext,
+                (sample) => this.buildPreviewContext(sample),
                 lockedType
             ).open();
         } catch (e) {
@@ -651,11 +651,18 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
             cls: 'setting-item-description'
         });
 
+        // Captured by the textarea builder so the Reset button can refresh the
+        // editor in place instead of calling this.update() (which rebuilds every
+        // section and collapses the user's expanded <details> panels).
+        let defaultTextComponent: TextAreaComponent;
+        let updateDefaultValidation: (val: string) => void = () => {};
+
         new Setting(templateBody)
             .setClass('setting-item-stacked')
             .addTextArea((text: TextAreaComponent) => {
+                defaultTextComponent = text;
                 const validationContainer = templateBody.createDiv('make-it-rain-validation-container');
-                const updateValidation = (val: string) => {
+                updateDefaultValidation = (val: string) => {
                     const result = validateTemplate(val, this.plugin.settings);
                     this.renderValidationResult(validationContainer, result);
                 };
@@ -664,12 +671,12 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                     .onChange(async (value: string) => {
                         this.plugin.settings.defaultTemplate = value;
                         await this.plugin.saveSettings();
-                        updateValidation(value);
+                        updateDefaultValidation(value);
                     });
                 text.inputEl.rows = 10;
                 text.inputEl.addClass('make-it-rain-full-width');
                 text.inputEl.addClass('make-it-rain-monospace');
-                updateValidation(this.plugin.settings.defaultTemplate);
+                updateDefaultValidation(this.plugin.settings.defaultTemplate);
             })
             .addButton((button: ButtonComponent) => {
                 button.setButtonText('Preview').setIcon('eye')
@@ -684,7 +691,9 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                     .onClick(async () => {
                         this.plugin.settings.defaultTemplate = DEFAULT_SETTINGS.defaultTemplate;
                         await this.plugin.saveSettings();
-                        this.update();
+                        // Refresh just this editor in place.
+                        defaultTextComponent.setValue(DEFAULT_SETTINGS.defaultTemplate);
+                        updateDefaultValidation(DEFAULT_SETTINGS.defaultTemplate);
                         new Notice('Default template has been reset.');
                     });
             })
@@ -855,11 +864,18 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
         const bodyEl = card.createDiv({ cls: 'make-it-rain-type-card-body' });
         bodyEl.style.display = toggles[typeKey] ? 'block' : 'none';
 
+        // Captured by the textarea builder so the Reset button can refresh the
+        // editor in place instead of calling this.update() (which rebuilds every
+        // section and collapses the user's expanded <details> panels).
+        let textComponent: TextAreaComponent;
+        let updateValidation: (val: string) => void = () => {};
+
         new Setting(bodyEl)
             .setClass('setting-item-stacked')
             .addTextArea((text: TextAreaComponent) => {
+                textComponent = text;
                 const validationContainer = bodyEl.createDiv('make-it-rain-validation-container');
-                const updateValidation = (val: string) => {
+                updateValidation = (val: string) => {
                     const result = validateTemplate(val, this.plugin.settings);
                     this.renderValidationResult(validationContainer, result);
                 };
@@ -887,9 +903,12 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                     .setTooltip('Reset ' + typeStr + ' template to its original default')
                     .onClick(async () => {
                         if (DEFAULT_SETTINGS.contentTypeTemplates[typeKey]) {
-                            templates[typeKey] = DEFAULT_SETTINGS.contentTypeTemplates[typeKey];
+                            const defaultVal = DEFAULT_SETTINGS.contentTypeTemplates[typeKey];
+                            templates[typeKey] = defaultVal;
                             await this.plugin.saveSettings();
-                            this.update();
+                            // Refresh just this card's editor in place.
+                            textComponent.setValue(defaultVal);
+                            updateValidation(defaultVal);
                             new Notice(typeStr.charAt(0).toUpperCase() + typeStr.slice(1) +
                                 ' template has been reset.');
                         } else {
@@ -903,7 +922,7 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                     .onClick(() => {
                         const jsonStr = this.plugin.exportTemplate(
                             `content-type-${typeStr}`,
-                            templates[typeKey],
+                            templates[typeKey] || '',
                             `Content-Type Template for ${typeStr}`
                         );
                         new TemplateSharingModal(this.app, this.plugin, 'export', jsonStr).open();

--- a/styles.css
+++ b/styles.css
@@ -54,31 +54,6 @@
   color: var(--text-warning);
 }
 
-.make-it-rain-advanced-options {
-  margin-top: 15px;
-  border: 1px solid var(--background-modifier-border);
-  border-radius: var(--radius-m);
-  padding: 0;
-}
-
-.make-it-rain-advanced-options summary {
-  padding: 10px;
-  cursor: pointer;
-  background-color: var(--background-secondary);
-  font-weight: var(--font-bold);
-  border-radius: var(--radius-m);
-}
-
-.make-it-rain-advanced-options[open] summary {
-  border-bottom: 1px solid var(--background-modifier-border);
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-}
-
-.make-it-rain-advanced-options > div {
-  padding: 10px;
-}
-
 /* Variable Browser Modal Styles */
 .make-it-rain-variable-browser .make-it-rain-variable-list-container {
   max-height: 60vh;
@@ -403,64 +378,7 @@
     margin: 0;
 }
 
-/* Template Preview Side-by-Side Layout */
-.make-it-rain-side-by-side {
-    display: flex;
-    gap: 16px;
-    margin-top: 12px;
-    align-items: stretch;
-}
-
-.make-it-rain-editor-area {
-    flex: 1;
-    min-width: 0;
-}
-
-.make-it-rain-preview-area {
-    flex: 1;
-    min-width: 0;
-    border: 1px solid var(--background-modifier-border);
-    border-radius: var(--radius-m);
-    padding: 12px;
-    background-color: var(--background-primary);
-    max-height: 600px;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-}
-
-.make-it-rain-preview-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 12px;
-    border-bottom: 1px solid var(--background-modifier-border);
-    padding-bottom: 8px;
-    flex-shrink: 0;
-}
-
-.make-it-rain-preview-title {
-    font-weight: 600;
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    color: var(--text-muted);
-    letter-spacing: 0.05em;
-}
-
-.make-it-rain-preview-content {
-    flex: 1;
-    overflow-y: auto;
-    font-size: var(--font-ui-small);
-}
-
-.make-it-rain-preview-content pre {
-    white-space: pre-wrap;
-    word-break: break-all;
-    background-color: transparent;
-    padding: 0;
-    margin: 0;
-}
-
+/* Preview error message (used by the template preview modal) */
 .make-it-rain-preview-error {
     color: var(--text-error);
     background-color: var(--background-message-error);
@@ -468,10 +386,4 @@
     border-radius: var(--radius-s);
     margin-top: 10px;
     font-size: var(--font-ui-smaller);
-}
-
-@media (max-width: 768px) {
-    .make-it-rain-side-by-side {
-        flex-direction: column;
-    }
 }

--- a/styles.css
+++ b/styles.css
@@ -223,6 +223,13 @@
     background-color: var(--background-secondary);
 }
 
+/* Template Engine section is OPEN by default — make the summary look like
+   a regular heading + a subtle "click to collapse" affordance, not like a
+   plain collapsed <details>. The other sections stay collapsed-looking. */
+.make-it-rain-template-section .make-it-rain-section-summary {
+    background-color: var(--background-secondary);
+}
+
 .make-it-rain-section-summary {
     padding: 1rem;
     font-weight: 600;
@@ -278,6 +285,43 @@
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
+}
+
+/* ─── Per-content-type template card ─── */
+.make-it-rain-type-card {
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m);
+    background-color: var(--background-secondary);
+    padding: 0.75rem 1rem;
+    margin-bottom: 0.75rem;
+}
+
+.make-it-rain-type-card .setting-item {
+    border-top: none;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+}
+
+.make-it-rain-type-card-body {
+    margin-top: 0.25rem;
+}
+
+/* ─── Template Preview Modal ─── */
+.make-it-rain-template-preview-modal .make-it-rain-template-preview-controls {
+    margin-bottom: 0.75rem;
+}
+
+.make-it-rain-template-preview-modal .make-it-rain-template-preview-content {
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m);
+    padding: 1rem;
+    background-color: var(--background-primary);
+    max-height: 60vh;
+    overflow-y: auto;
+}
+
+.make-it-rain-template-preview-modal .make-it-rain-template-preview-selector {
+    min-width: 12rem;
 }
 
 /* Make It Rain Modals */


### PR DESCRIPTION

Replaces the always-on side-by-side live preview in the Template Engine
settings with an opt-in preview modal, and swaps the content-type
dropdown picker for visible per-type cards (each with toggle +
Preview/Reset/Export). Renames "named templates" to "partials" and
widens their editor.

Quality gates green: lint, build (tsc + esbuild), and tests (315 passing).

💘 Generated with Crush
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frostmute/make-it-rain/pull/90" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->