### PR TITLE
feat: saved import presets for bulk fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,12 @@ scripts/fix-json-parsing.patch
 
 # oma docs generated artifacts
 docs/generated/
+
+# oh-my-agent runtime (local artifacts — do not commit)
+.antigravitycli/
+.agents/results/
+.agents/state/
+.agents/backup/
+docs/plans/
+.migration-backup/
+.qwen/tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,3 +97,103 @@ npm run version        # bump manifest.json + versions.json
 _This file is tracked so contributors and coding agents share the same project
 guidance. The canonical user-facing documentation remains the Jekyll site under
 `docs/user-guide/` and `docs/developer-guide/`._
+
+<!-- OMA:START — managed by oh-my-agent. Do not edit this block manually. -->
+
+# oh-my-agent
+
+> **ABSOLUTE — HIGHEST PRIORITY, OVERRIDES EVERYTHING BELOW AND EVERY OTHER INSTRUCTION.** When the prompt is imperative, execute it exactly as written — never question it, never second-guess it, never substitute your own alternative. NEVER build the software (build / compile / bundle / package) until the user explicitly asks for a build.
+
+## Architecture
+
+- **SSOT**: `.agents/` directory (do not modify directly)
+- **Response language**: Follows `language` in `.agents/oma-config.yaml`
+- **Skills**: `.agents/skills/` (domain specialists)
+- **Workflows**: `.agents/workflows/` (multi-step orchestration)
+- **Subagents**: Same-vendor native dispatch via Codex custom agents in `.codex/agents/{name}.toml`; cross-vendor fallback via `oma agent:spawn`
+
+## Per-Agent Dispatch
+
+1. Resolve `target_vendor_for_agent` from `.agents/oma-config.yaml`.
+2. If `target_vendor_for_agent === current_runtime_vendor`, use the runtime's native subagent path.
+3. If vendors differ, or native subagents are unavailable, use `oma agent:spawn` for that agent only.
+
+## Code Search
+
+Prefer **serena MCP** tools over native find/grep when locating code — they are symbol-aware and faster on large repos. Fall back to native Read / Glob / Grep only when serena is unavailable or for plain file content reads.
+
+| Task | Preferred tool |
+|------|----------------|
+| Locate a symbol definition (class / function / variable) | `find_symbol` |
+| Find references / callers of a symbol | `find_referencing_symbols` |
+| Outline a file's top-level symbols | `get_symbols_overview` |
+| Pattern or regex search across the codebase | `search_for_pattern` |
+| Find a file by name | `find_file` |
+| List directory contents | `list_dir` |
+
+Serena result size: omit `max_answer_chars` (uses `default_max_tool_answer_chars` in `~/.serena/serena_config.yml`, typically 150000) unless you need a hard cap. Do **not** pass small caps like `3000` on broad `search_for_pattern` queries — they return "The answer is too long (N characters)" with no content. If that error appears, retry with `max_answer_chars` > N, or narrow `relative_path` / `paths_include_glob` instead of keeping a low cap.
+
+## Workflows
+
+Execute by naming the workflow in your prompt. Keywords are auto-detected via hooks.
+
+| Workflow | File | Description |
+|----------|------|-------------|
+| orchestrate | `orchestrate.md` | Parallel subagents + Review Loop |
+| work | `work.md` | Step-by-step with remediation loop |
+| ultrawork | `ultrawork.md` | 5-Phase Gate Loop with cross-context reviews |
+| ralph | `ralph.md` | Persistent loop wrapping ultrawork with an independent judge |
+| plan | `plan.md` | PM task breakdown |
+| brainstorm | `brainstorm.md` | Design-first ideation |
+| architecture | `architecture.md` | Architecture diagnosis, comparison, ADR |
+| design | `design.md` | Design system + DESIGN.md with anti-pattern enforcement |
+| review | `review.md` | QA audit |
+| debug | `debug.md` | Root cause + minimal fix |
+| deepsec | `deepsec.md` | Drive `oma-deepsec` end-to-end (setup / scan / pr-review / matchers / triage / config / troubleshoot) |
+| scm | `scm.md` | SCM + Git operations + Conventional Commits |
+| docs | `docs.md` | Documentation drift verify + sync |
+| recap | `recap.md` | Daily / period AI conversation recap |
+| deepinit | `deepinit.md` | Project harness init (AGENTS.md / ARCHITECTURE.md / docs/) |
+| convert | `convert.md` | File format conversion by category: documents→Markdown (oma-pdf/oma-hwp), image/video/audio transcode (ffmpeg) |
+| video | `video.md` | Brief → script → assets → render-spec → Remotion (oma-video) |
+| schedule | `schedule.md` | Register & manage time-based agent jobs via `oma schedule:*` |
+| explain | `explain.md` | Diff/PR/branch → self-contained interactive HTML explainer via oma-explainer |
+
+(`tools` and `stack-set` are slash-invoked utilities, `schedule` is a slash-invoked workflow (`oma schedule:*` time-based jobs), `convert` is slash-invoked to avoid false positives on "convert this code" phrasing, and `explain` is slash-invoked because "explain" is everyday vocabulary, excluded from keyword detection to avoid false positives; all are intentionally excluded from keyword detection.)
+
+To execute: read and follow `.agents/workflows/{name}.md` step by step.
+
+## Auto-Detection
+
+Hooks: `UserPromptSubmit` (keyword detection), `PreToolUse`, `Stop` (persistent mode)
+Keywords defined in `.agents/hooks/core/triggers.json` (multi-language).
+Persistent workflows (orchestrate, ultrawork, work, ralph) block termination until complete.
+Deactivate: say "workflow done".
+
+## Rules
+
+1. **Do not modify `.agents/` files** (SSOT protection).
+2. Workflows execute via keyword detection or explicit naming, never self-initiated.
+3. Response language follows `.agents/oma-config.yaml`
+
+## Project Rules
+
+Read the relevant file from `.agents/rules/` when working on matching code.
+
+| Rule | File | Scope |
+|------|------|-------|
+| backend | `.agents/rules/backend.md` | on request |
+| commit | `.agents/rules/commit.md` | on request |
+| database | `.agents/rules/database.md` | **/*.{sql,prisma} |
+| debug | `.agents/rules/debug.md` | on request |
+| design | `.agents/rules/design.md` | on request |
+| dev-workflow | `.agents/rules/dev-workflow.md` | on request |
+| frontend | `.agents/rules/frontend.md` | **/*.{tsx,jsx,css,scss} |
+| i18n-arb | `.agents/rules/i18n-arb.md` | **/*.arb |
+| i18n-guide | `.agents/rules/i18n-guide.md` | always |
+| infrastructure | `.agents/rules/infrastructure.md` | **/*.{tf,tfvars,hcl} |
+| market | `.agents/rules/market.md` | on request |
+| mobile | `.agents/rules/mobile.md` | **/*.{dart,swift,kt} |
+| quality | `.agents/rules/quality.md` | on request |
+
+<!-- OMA:END -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Make It Rain plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Saved import presets.** Capture a full bulk-import configuration (collections, tag filter and match mode, content type, subcollections, destination folder, append tags, filename source, fetch-only-new / update-existing, and template overrides) as a named preset and reload it from the fetch modal. Each preset also registers a `Fetch: {preset name}` command in the command palette, and presets can be renamed or deleted from the new **Import Presets** section in plugin settings.
+
 ## [2.1.1] - 2026-08-09
 
 ### Added

--- a/docs/product-specs/import-presets.md
+++ b/docs/product-specs/import-presets.md
@@ -1,0 +1,44 @@
+# Import Presets
+
+**Status:** Shipped.
+
+## User Story
+
+> As a user who repeats the same bulk imports (a reading backlog, a
+> research collection, a tag-filtered slice), I want to save a fetch
+> configuration under a name and re-run it in one click, instead of
+> re-entering collections, tag filters, destination folder, and toggles
+> every time.
+
+## Acceptance Criteria
+
+- [x] The bulk import modal has a **Presets** section with a preset
+      chooser, **Save current as preset**, and **Delete preset**.
+- [x] Saving prompts for a name; saving with an existing name updates
+      that preset and keeps its identity (its command palette entry
+      stays bound).
+- [x] Selecting a preset applies every captured option and redraws the
+      modal: collections, tag filter and match mode (AND/OR), content
+      type filter, include subcollections, save destination, append
+      tags, use Raindrop title for filename, fetch-only-new,
+      update-existing, and both template overrides.
+- [x] Selecting the blank "no preset" entry restores the modal defaults
+      and disables the Delete button — no values from the previously
+      loaded preset remain in effect.
+- [x] Each saved preset registers a `Fetch: {preset name}` command in
+      the command palette, running the import with no further prompts.
+      Commands are re-registered when presets are created, renamed,
+      updated, or deleted.
+- [x] The plugin settings screen has an **Import Presets** section that
+      lists every saved preset with a summary of its options, and lets
+      the user rename or delete it. Renaming rejects a name already
+      used by another preset.
+- [x] Settings saved before this feature (no `importPresets` field)
+      load as an empty preset list; modal defaults are unchanged.
+
+## Out of Scope
+
+- Scheduled or automatic execution of presets.
+- Sharing/exporting presets between vaults (template import/export is a
+  separate feature).
+- Presets for quick import or highlights aggregation.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -17,6 +17,7 @@
 | [Per-content-type templates](per-content-type-templates.md) | Shipped | Configure Markdown output per Raindrop content type (link, article, image, video, document, audio, book) |
 | [Folder notes](folder-notes.md) | Shipped | Auto-generate index notes for each collection folder |
 | [Binary attachment download](binary-attachment-download.md) | Shipped | Download native Raindrop file attachments (PDF, EPUB, image, video, audio) |
+| [Import presets](import-presets.md) | Shipped | Save named bulk-import configurations and re-run them from the modal or command palette |
 
 ## Conventions
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ import {
 
 // Import utility functions from consolidated index
 import { DEFAULT_SETTINGS, RaindropToObsidianSettingTab } from './settings';
-import { RaindropFetchModal, QuickImportModal, HighlightsAggregateModal, SafeSyncModal } from './modals';
+import { RaindropFetchModal, QuickImportModal, HighlightsAggregateModal, SafeSyncModal, importPresetToOptions } from './modals';
 
 import { 
     // File utilities
@@ -97,6 +97,7 @@ export default class RaindropToObsidian extends Plugin implements IRaindropToObs
     private lastCollectionFetch: number = 0;
     private lastGroupFetch: number = 0;
     private readonly CACHE_TTL = 5 * 60 * 1000; // 5 minutes cache
+    private registeredPresetCommandIds: string[] = [];
 
     constructor(app: App, manifest: PluginManifest) {
         super(app, manifest);
@@ -141,6 +142,9 @@ export default class RaindropToObsidian extends Plugin implements IRaindropToObs
             }
         });
 
+        // One command-palette entry per saved preset (e.g. "Fetch: Reading backlog")
+        this.refreshPresetCommands();
+
         this.addSettingTab(new RaindropToObsidianSettingTab(this.app, this));
         console.debug('Make It Rain plugin loaded!');
     }
@@ -148,6 +152,32 @@ export default class RaindropToObsidian extends Plugin implements IRaindropToObs
     onunload() {
         this.ribbonIconEl?.remove();
         console.debug('Make It Rain plugin unloaded.');
+    }
+
+    /**
+     * (Re)register one command-palette entry per saved import preset
+     * ("Fetch: {preset name}"). Called on plugin load and whenever presets
+     * are created, updated, or deleted so the palette never goes stale.
+     * Command ids are derived from the preset's stable id, so re-running
+     * this method is idempotent.
+     */
+    refreshPresetCommands(): void {
+        for (const id of this.registeredPresetCommandIds) {
+            this.removeCommand(id);
+        }
+        this.registeredPresetCommandIds = [];
+
+        for (const preset of this.settings.importPresets || []) {
+            const id = `fetch-preset-${preset.id}`;
+            this.addCommand({
+                id,
+                name: `Fetch: ${preset.name}`,
+                callback: () => {
+                    void this.fetchRaindrops(importPresetToOptions(preset));
+                }
+            });
+            this.registeredPresetCommandIds.push(id);
+        }
     }
 
     async loadSettings(): Promise<void> {
@@ -160,6 +190,9 @@ export default class RaindropToObsidian extends Plugin implements IRaindropToObs
             this.settings = {
                 ...this.settings,
                 ...data,
+                // Presets are optional in saved data (pre-2.2.0); default to an
+                // empty list so iteration never touches a non-array.
+                importPresets: Array.isArray(data.importPresets) ? data.importPresets : [],
                 contentTypeTemplates: {
                     ...this.settings.contentTypeTemplates,
                     ...(data.contentTypeTemplates

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ import {
 
 // Import utility functions from consolidated index
 import { DEFAULT_SETTINGS, RaindropToObsidianSettingTab } from './settings';
-import { RaindropFetchModal, QuickImportModal, HighlightsAggregateModal, SafeSyncModal, importPresetToOptions } from './modals';
+import { RaindropFetchModal, QuickImportModal, HighlightsAggregateModal, SafeSyncModal, importPresetToOptions, normalizeImportPresets } from './modals';
 
 import { 
     // File utilities
@@ -192,7 +192,7 @@ export default class RaindropToObsidian extends Plugin implements IRaindropToObs
                 ...data,
                 // Presets are optional in saved data (pre-2.2.0); default to an
                 // empty list so iteration never touches a non-array.
-                importPresets: Array.isArray(data.importPresets) ? data.importPresets : [],
+                importPresets: normalizeImportPresets(data.importPresets),
                 contentTypeTemplates: {
                     ...this.settings.contentTypeTemplates,
                     ...(data.contentTypeTemplates

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -7,9 +7,65 @@ import {
     TagMatchTypes,
     RaindropTypes,
     ModalFetchOptions,
-    AggregateHighlightsOptions
+    AggregateHighlightsOptions,
+    ImportPreset,
+    ImportPresetFields
 } from './types';
 import { SAMPLE_RAINDROPS } from './utils/sampleData';
+
+/**
+ * Build a unique, URL-safe id for a new preset. Kept dependency-free
+ * (no crypto imports) — collision odds are negligible for this use case.
+ */
+function generatePresetId(): string {
+    return 'preset-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 10);
+}
+
+/**
+ * Convert a preset's captured fields into the options object the fetch
+ * pipeline expects. Shared by the modal (live fetch) and the per-preset
+ * command-palette entries so both paths stay in lockstep.
+ */
+export function importPresetToOptions(preset: ImportPresetFields): ModalFetchOptions {
+    return {
+        collections: preset.collections,
+        apiFilterTags: preset.apiFilterTags,
+        vaultPath: preset.vaultPath,
+        appendTagsToNotes: preset.appendTagsToNotes,
+        useRaindropTitleForFileName: preset.useRaindropTitleForFileName,
+        tagMatchType: preset.tagMatchType,
+        filterType: preset.filterType,
+        includeSubcollections: preset.includeSubcollections,
+        fetchOnlyNew: preset.fetchOnlyNew,
+        updateExisting: preset.updateExisting,
+        useDefaultTemplate: preset.useDefaultTemplate,
+        overrideTemplates: preset.overrideTemplates
+    };
+}
+
+/**
+ * Create or update a preset by name (case-sensitive). Updating keeps the
+ * existing id so command-palette bindings stay stable across edits.
+ */
+export function upsertPreset(
+    presets: ImportPreset[],
+    name: string,
+    fields: ImportPresetFields
+): { presets: ImportPreset[]; preset: ImportPreset; created: boolean } {
+    const existingIndex = presets.findIndex(p => p.name === name);
+    const preset: ImportPreset = {
+        id: existingIndex >= 0 ? presets[existingIndex].id : generatePresetId(),
+        name,
+        ...fields
+    };
+    const next = presets.slice();
+    if (existingIndex >= 0) {
+        next[existingIndex] = preset;
+    } else {
+        next.push(preset);
+    }
+    return { presets: next, preset, created: existingIndex < 0 };
+}
 
 /**
  * Modal for fetching raindrops with filters
@@ -28,6 +84,7 @@ export class RaindropFetchModal extends Modal {
     updateExisting: boolean = false;
     useDefaultTemplate: boolean = false;
     overrideTemplates: boolean = false;
+    selectedPresetId: string = '';
 
     constructor(app: App, plugin: RaindropToObsidian) {
         super(app);
@@ -35,8 +92,15 @@ export class RaindropFetchModal extends Modal {
         this.vaultPath = plugin.settings.defaultFolder;
     }
 
-
     onOpen() {
+        this.render();
+    }
+
+    /**
+     * Render the full modal body. Called on open and again whenever a preset
+     * is loaded/saved/deleted so every control reflects the current state.
+     */
+    render() {
         const { contentEl } = this;
         contentEl.empty();
         contentEl.addClass('make-it-rain-modal');
@@ -49,6 +113,47 @@ export class RaindropFetchModal extends Modal {
             cls: 'setting-item-description'
         });
         
+        contentEl.createEl('hr');
+
+        // --- 0. Presets ---
+        const presetGroup = contentEl.createDiv({ cls: 'make-it-rain-modal-group' });
+        presetGroup.createEl('h3', { text: 'Presets', cls: 'make-it-rain-h3' });
+
+        const presets = this.plugin.settings.importPresets || [];
+        const presetSetting = new Setting(presetGroup)
+            .setName('Import preset')
+            .setDesc('Load a saved fetch configuration, or save the current one to reuse later. Selecting a preset overwrites the fields below.');
+
+        presetSetting.addDropdown((dropdown: DropdownComponent) => {
+            dropdown.addOption('', '— Default (no preset) —');
+            presets.forEach(preset => dropdown.addOption(preset.id, preset.name));
+            dropdown.setValue(this.selectedPresetId)
+                .onChange((value: string) => {
+                    this.selectedPresetId = value;
+                    const preset = presets.find(p => p.id === value);
+                    if (preset) {
+                        this.applyPreset(preset);
+                        this.render();
+                    }
+                });
+        });
+
+        presetSetting.addButton((button: ButtonComponent) => {
+            button.setButtonText('Save current as preset')
+                .setIcon('save')
+                .setTooltip('Save the current fetch configuration as a reusable preset')
+                .onClick(() => this.openSavePresetModal());
+        });
+
+        presetSetting.addButton((button: ButtonComponent) => {
+            button.setButtonText('Delete preset')
+                .setIcon('trash')
+                .setDestructive()
+                .setTooltip('Delete the currently selected preset')
+                .setDisabled(!this.selectedPresetId)
+                .onClick(() => this.deleteSelectedPreset());
+        });
+
         contentEl.createEl('hr');
 
         // --- 1. Source & Scope ---
@@ -228,26 +333,94 @@ export class RaindropFetchModal extends Modal {
             .setCta()
             .onClick(() => {
                 this.close();
-                const options: ModalFetchOptions = {
-                    collections: this.collections,
-                    apiFilterTags: this.apiFilterTags,
-                    vaultPath: this.vaultPath,
-                    appendTagsToNotes: this.appendTagsToNotes,
-                    useRaindropTitleForFileName: this.useRaindropTitleForFileName,
-                    tagMatchType: this.tagMatchType,
-                    filterType: this.filterType,
-                    includeSubcollections: this.includeSubcollections,
-                    fetchOnlyNew: this.fetchOnlyNew,
-                    updateExisting: this.updateExisting,
-                    useDefaultTemplate: this.useDefaultTemplate,
-                    overrideTemplates: this.overrideTemplates
-                };
-                void this.plugin.fetchRaindrops(options);
+                void this.plugin.fetchRaindrops(this.getFetchOptions());
             });
             
         new ButtonComponent(buttonsEl)
             .setButtonText('Cancel')
             .onClick(() => this.close());
+    }
+
+    /**
+     * Snapshot the modal's current field values into a preset payload
+     * (everything except id/name, which are assigned on save).
+     */
+    private toPresetFields(): ImportPresetFields {
+        return {
+            vaultPath: this.vaultPath,
+            collections: this.collections,
+            apiFilterTags: this.apiFilterTags,
+            includeSubcollections: this.includeSubcollections,
+            appendTagsToNotes: this.appendTagsToNotes,
+            useRaindropTitleForFileName: this.useRaindropTitleForFileName,
+            tagMatchType: this.tagMatchType,
+            filterType: this.filterType,
+            fetchOnlyNew: this.fetchOnlyNew,
+            updateExisting: this.updateExisting,
+            useDefaultTemplate: this.useDefaultTemplate,
+            overrideTemplates: this.overrideTemplates
+        };
+    }
+
+    /**
+     * Build the ModalFetchOptions for the current field values. Kept in one
+     * place so the live fetch and preset snapshots stay identical.
+     */
+    private getFetchOptions(): ModalFetchOptions {
+        return importPresetToOptions(this.toPresetFields());
+    }
+
+    /**
+     * Overwrite the modal fields with a preset's captured values.
+     */
+    private applyPreset(preset: ImportPreset): void {
+        this.vaultPath = preset.vaultPath;
+        this.collections = preset.collections;
+        this.apiFilterTags = preset.apiFilterTags;
+        this.includeSubcollections = preset.includeSubcollections;
+        this.appendTagsToNotes = preset.appendTagsToNotes;
+        this.useRaindropTitleForFileName = preset.useRaindropTitleForFileName;
+        this.tagMatchType = preset.tagMatchType;
+        this.filterType = preset.filterType;
+        this.fetchOnlyNew = preset.fetchOnlyNew;
+        this.updateExisting = preset.updateExisting;
+        this.useDefaultTemplate = preset.useDefaultTemplate;
+        this.overrideTemplates = preset.overrideTemplates;
+    }
+
+    /**
+     * Open the name-entry modal, then persist the current fields as a new
+     * preset (or update the preset with the same name), refresh the
+     * per-preset commands, and re-render to select the saved preset.
+     */
+    private openSavePresetModal(): void {
+        const presets = this.plugin.settings.importPresets || [];
+        const existing = presets.find(p => p.id === this.selectedPresetId);
+        new SavePresetModal(this.app, this.plugin, existing?.name || '', async (name: string) => {
+            const result = upsertPreset(presets, name, this.toPresetFields());
+            this.plugin.settings.importPresets = result.presets;
+            await this.plugin.saveSettings();
+            this.plugin.refreshPresetCommands();
+            this.selectedPresetId = result.preset.id;
+            new Notice(result.created ? `Preset "${name}" saved.` : `Preset "${name}" updated.`);
+            this.render();
+        }).open();
+    }
+
+    /**
+     * Delete the currently selected preset, refresh commands, and re-render.
+     */
+    private deleteSelectedPreset(): void {
+        const presets = this.plugin.settings.importPresets || [];
+        const index = presets.findIndex(p => p.id === this.selectedPresetId);
+        if (index < 0) return;
+        const [removed] = presets.splice(index, 1);
+        void this.plugin.saveSettings().then(() => {
+            this.plugin.refreshPresetCommands();
+            this.selectedPresetId = '';
+            new Notice(`Preset "${removed.name}" deleted.`);
+            this.render();
+        });
     }
 
     private buildFetchCriteriaSection(contentEl: HTMLElement) {
@@ -566,6 +739,66 @@ export class RaindropFetchModal extends Modal {
             .onClick(() => {
                 this.close();
             });
+    }
+
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+    }
+}
+
+/**
+ * Modal for naming and saving an import preset.
+ */
+export class SavePresetModal extends Modal {
+    plugin: RaindropToObsidian;
+    initialName: string;
+    onSubmit: (name: string) => Promise<void> | void;
+
+    constructor(app: App, plugin: RaindropToObsidian, initialName: string, onSubmit: (name: string) => Promise<void> | void) {
+        super(app);
+        this.plugin = plugin;
+        this.initialName = initialName;
+        this.onSubmit = onSubmit;
+    }
+
+    onOpen() {
+        const { contentEl } = this;
+        contentEl.empty();
+        contentEl.addClass('make-it-rain-modal');
+
+        contentEl.createEl('h3', { text: 'Save import preset', cls: 'make-it-rain-h3' });
+        contentEl.createEl('p', {
+            text: 'Save the current fetch configuration as a reusable preset. If a preset with this name already exists, it will be updated.',
+            cls: 'setting-item-description'
+        });
+
+        let nameInput: TextComponent;
+        new Setting(contentEl)
+            .setName('Preset name')
+            .addText((text: TextComponent) => {
+                nameInput = text;
+                text.setValue(this.initialName)
+                    .setPlaceholder('e.g. Reading backlog');
+                text.inputEl.addClass('make-it-rain-full-width');
+            });
+
+        const buttonsEl = contentEl.createDiv({ cls: 'modal-button-container' });
+        new ButtonComponent(buttonsEl)
+            .setButtonText('Save')
+            .setCta()
+            .onClick(() => {
+                const name = nameInput.getValue().trim();
+                if (!name) {
+                    new Notice('Please enter a preset name.');
+                    return;
+                }
+                void Promise.resolve(this.onSubmit(name)).then(() => this.close());
+            });
+
+        new ButtonComponent(buttonsEl)
+            .setButtonText('Cancel')
+            .onClick(() => this.close());
     }
 
     onClose() {

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -442,6 +442,7 @@ export class RaindropFetchModal extends Modal {
         void this.plugin.saveSettings().then(() => {
             this.plugin.refreshPresetCommands();
             this.selectedPresetId = '';
+            this.resetToDefaults();
             new Notice(`Preset "${removed.name}" deleted.`);
             this.render();
         });
@@ -777,7 +778,11 @@ export class RaindropFetchModal extends Modal {
 export class SavePresetModal extends Modal {
     plugin: RaindropToObsidian;
     initialName: string;
-    onSubmit: (name: string) => Promise<void> | void;
+    /**
+     * Handle the entered name. Return `false` (or throw) to reject it and keep
+     * the dialog open so the user can correct their input.
+     */
+    onSubmit: (name: string) => Promise<boolean | void> | boolean | void;
     title: string;
     description: string;
 
@@ -785,7 +790,7 @@ export class SavePresetModal extends Modal {
         app: App,
         plugin: RaindropToObsidian,
         initialName: string,
-        onSubmit: (name: string) => Promise<void> | void,
+        onSubmit: (name: string) => Promise<boolean | void> | boolean | void,
         title: string = 'Save import preset',
         description: string = 'Save the current fetch configuration as a reusable preset. If a preset with this name already exists, it will be updated.'
     ) {
@@ -818,17 +823,36 @@ export class SavePresetModal extends Modal {
                 text.inputEl.addClass('make-it-rain-full-width');
             });
 
+        const errorEl = contentEl.createDiv({ cls: 'make-it-rain-error-text' });
+        errorEl.style.display = 'none';
+
+        const showError = (message: string) => {
+            errorEl.textContent = message;
+            errorEl.style.display = '';
+        };
+
         const buttonsEl = contentEl.createDiv({ cls: 'modal-button-container' });
         new ButtonComponent(buttonsEl)
             .setButtonText('Save')
             .setCta()
             .onClick(() => {
+                errorEl.style.display = 'none';
                 const name = nameInput.getValue().trim();
                 if (!name) {
-                    new Notice('Please enter a preset name.');
+                    showError('Please enter a preset name.');
                     return;
                 }
-                void Promise.resolve(this.onSubmit(name)).then(() => this.close());
+                // The handler rejects a name by returning false (or throwing);
+                // keep the dialog open in that case so the typed name survives.
+                void Promise.resolve(this.onSubmit(name))
+                    .then(accepted => {
+                        if (accepted !== false) this.close();
+                    })
+                    .catch((e: unknown) => {
+                        const message = e instanceof Error ? e.message : String(e);
+                        console.error('Preset name submission failed:', e);
+                        showError(message);
+                    });
             });
 
         new ButtonComponent(buttonsEl)

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -129,12 +129,18 @@ export class RaindropFetchModal extends Modal {
             presets.forEach(preset => dropdown.addOption(preset.id, preset.name));
             dropdown.setValue(this.selectedPresetId)
                 .onChange((value: string) => {
-                    this.selectedPresetId = value;
                     const preset = presets.find(p => p.id === value);
                     if (preset) {
+                        this.selectedPresetId = preset.id;
                         this.applyPreset(preset);
-                        this.render();
+                    } else {
+                        // Blank entry (or a preset that vanished): drop back to
+                        // the modal defaults instead of silently keeping the
+                        // previously loaded preset's values.
+                        this.selectedPresetId = '';
+                        this.resetToDefaults();
                     }
+                    this.render();
                 });
         });
 
@@ -368,6 +374,24 @@ export class RaindropFetchModal extends Modal {
      */
     private getFetchOptions(): ModalFetchOptions {
         return importPresetToOptions(this.toPresetFields());
+    }
+
+    /**
+     * Restore every field to the modal's initial (no preset) state.
+     */
+    resetToDefaults(): void {
+        this.vaultPath = this.plugin.settings.defaultFolder;
+        this.collections = '';
+        this.apiFilterTags = '';
+        this.includeSubcollections = true;
+        this.appendTagsToNotes = '';
+        this.useRaindropTitleForFileName = true;
+        this.tagMatchType = TagMatchTypes.ALL;
+        this.filterType = 'all';
+        this.fetchOnlyNew = true;
+        this.updateExisting = false;
+        this.useDefaultTemplate = false;
+        this.overrideTemplates = false;
     }
 
     /**
@@ -754,12 +778,23 @@ export class SavePresetModal extends Modal {
     plugin: RaindropToObsidian;
     initialName: string;
     onSubmit: (name: string) => Promise<void> | void;
+    title: string;
+    description: string;
 
-    constructor(app: App, plugin: RaindropToObsidian, initialName: string, onSubmit: (name: string) => Promise<void> | void) {
+    constructor(
+        app: App,
+        plugin: RaindropToObsidian,
+        initialName: string,
+        onSubmit: (name: string) => Promise<void> | void,
+        title: string = 'Save import preset',
+        description: string = 'Save the current fetch configuration as a reusable preset. If a preset with this name already exists, it will be updated.'
+    ) {
         super(app);
         this.plugin = plugin;
         this.initialName = initialName;
         this.onSubmit = onSubmit;
+        this.title = title;
+        this.description = description;
     }
 
     onOpen() {
@@ -767,9 +802,9 @@ export class SavePresetModal extends Modal {
         contentEl.empty();
         contentEl.addClass('make-it-rain-modal');
 
-        contentEl.createEl('h3', { text: 'Save import preset', cls: 'make-it-rain-h3' });
+        contentEl.createEl('h3', { text: this.title, cls: 'make-it-rain-h3' });
         contentEl.createEl('p', {
-            text: 'Save the current fetch configuration as a reusable preset. If a preset with this name already exists, it will be updated.',
+            text: this.description,
             cls: 'setting-item-description'
         });
 

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -445,6 +445,12 @@ export class RaindropFetchModal extends Modal {
             this.resetToDefaults();
             new Notice(`Preset "${removed.name}" deleted.`);
             this.render();
+        }).catch((e: unknown) => {
+            // Roll back the in-memory removal so the list and disk agree.
+            presets.splice(index, 0, removed);
+            console.error('Failed to delete preset:', e);
+            new Notice(`Could not delete preset "${removed.name}": ${e instanceof Error ? e.message : String(e)}`);
+            this.render();
         });
     }
 

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -68,6 +68,49 @@ export function upsertPreset(
 }
 
 /**
+ * Coerce persisted preset records into well-formed `ImportPreset`s. Saved
+ * data can be hand-edited or written by an older version, so every field is
+ * defaulted and entries without a usable id/name are dropped.
+ */
+export function normalizeImportPresets(value: unknown): ImportPreset[] {
+    if (!Array.isArray(value)) return [];
+
+    const str = (input: unknown, fallback = ''): string =>
+        typeof input === 'string' ? input : fallback;
+    const bool = (input: unknown, fallback: boolean): boolean =>
+        typeof input === 'boolean' ? input : fallback;
+
+    return value.reduce<ImportPreset[]>((presets, entry) => {
+        if (!entry || typeof entry !== 'object') return presets;
+        const raw = entry as Record<string, unknown>;
+        const id = str(raw.id);
+        const name = str(raw.name);
+        if (!id || !name) return presets;
+
+        const filterType = str(raw.filterType, 'all');
+        presets.push({
+            id,
+            name,
+            vaultPath: str(raw.vaultPath),
+            collections: str(raw.collections),
+            apiFilterTags: str(raw.apiFilterTags),
+            includeSubcollections: bool(raw.includeSubcollections, true),
+            appendTagsToNotes: str(raw.appendTagsToNotes),
+            useRaindropTitleForFileName: bool(raw.useRaindropTitleForFileName, true),
+            tagMatchType: raw.tagMatchType === TagMatchTypes.ANY ? TagMatchTypes.ANY : TagMatchTypes.ALL,
+            filterType: (Object.values(RaindropTypes) as string[]).includes(filterType)
+                ? filterType as RaindropType
+                : 'all',
+            fetchOnlyNew: bool(raw.fetchOnlyNew, true),
+            updateExisting: bool(raw.updateExisting, false),
+            useDefaultTemplate: bool(raw.useDefaultTemplate, false),
+            overrideTemplates: bool(raw.overrideTemplates, false)
+        });
+        return presets;
+    }, []);
+}
+
+/**
  * Modal for fetching raindrops with filters
  */
 export class RaindropFetchModal extends Modal {
@@ -85,6 +128,8 @@ export class RaindropFetchModal extends Modal {
     useDefaultTemplate: boolean = false;
     overrideTemplates: boolean = false;
     selectedPresetId: string = '';
+    /** Set before a re-render triggered by the preset controls. */
+    private refocusPresetDropdown: boolean = false;
 
     constructor(app: App, plugin: RaindropToObsidian) {
         super(app);
@@ -127,6 +172,12 @@ export class RaindropFetchModal extends Modal {
         presetSetting.addDropdown((dropdown: DropdownComponent) => {
             dropdown.addOption('', '— Default (no preset) —');
             presets.forEach(preset => dropdown.addOption(preset.id, preset.name));
+            // Re-rendering rebuilds the dropdown, so put focus back on it when
+            // the render was triggered by the preset controls themselves.
+            if (this.refocusPresetDropdown) {
+                this.refocusPresetDropdown = false;
+                dropdown.selectEl.focus();
+            }
             dropdown.setValue(this.selectedPresetId)
                 .onChange((value: string) => {
                     const preset = presets.find(p => p.id === value);
@@ -140,6 +191,7 @@ export class RaindropFetchModal extends Modal {
                         this.selectedPresetId = '';
                         this.resetToDefaults();
                     }
+                    this.refocusPresetDropdown = true;
                     this.render();
                 });
         });
@@ -421,12 +473,21 @@ export class RaindropFetchModal extends Modal {
         const presets = this.plugin.settings.importPresets || [];
         const existing = presets.find(p => p.id === this.selectedPresetId);
         new SavePresetModal(this.app, this.plugin, existing?.name || '', async (name: string) => {
+            const previous = this.plugin.settings.importPresets;
             const result = upsertPreset(presets, name, this.toPresetFields());
             this.plugin.settings.importPresets = result.presets;
-            await this.plugin.saveSettings();
+            try {
+                await this.plugin.saveSettings();
+            } catch (e: unknown) {
+                // Never leave an unsaved preset in memory: a later unrelated
+                // save would silently persist it.
+                this.plugin.settings.importPresets = previous;
+                throw e;
+            }
             this.plugin.refreshPresetCommands();
             this.selectedPresetId = result.preset.id;
             new Notice(result.created ? `Preset "${name}" saved.` : `Preset "${name}" updated.`);
+            this.refocusPresetDropdown = true;
             this.render();
         }).open();
     }
@@ -444,6 +505,7 @@ export class RaindropFetchModal extends Modal {
             this.selectedPresetId = '';
             this.resetToDefaults();
             new Notice(`Preset "${removed.name}" deleted.`);
+            this.refocusPresetDropdown = true;
             this.render();
         }).catch((e: unknown) => {
             // Roll back the in-memory removal so the list and disk agree.

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,8 +1,8 @@
 import { App, PluginSettingTab, Setting, TextComponent, ButtonComponent, Notice, request, ToggleComponent, TextAreaComponent, DropdownComponent } from 'obsidian';
 import type RaindropToObsidian from './main';
 import { RaindropTypes, RaindropType } from './types';
-import { MakeItRainSettings, TemplateData } from './types';
-import { VariableBrowserModal, TemplateSharingModal, TemplatePreviewModal } from './modals';
+import { ImportPreset, MakeItRainSettings, TemplateData } from './types';
+import { VariableBrowserModal, TemplateSharingModal, TemplatePreviewModal, SavePresetModal } from './modals';
 import { validateTemplate, ValidationResult } from './template-validator';
 import { SampleRaindrop } from './utils/sampleData';
 
@@ -593,7 +593,13 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                 text.inputEl.addClass('make-it-rain-full-width');
             });
 
-        // --- 5. Template Engine ---
+        // --- 5. Import Presets ---
+        const presetSection = containerEl.createEl('details', { cls: 'make-it-rain-settings-section' });
+        presetSection.createEl('summary', { text: 'Import Presets', cls: 'make-it-rain-section-summary' });
+        const presetContent = presetSection.createDiv({ cls: 'make-it-rain-section-content' });
+        this.renderImportPresets(presetContent);
+
+        // --- 6. Template Engine ---
         // Section is OPEN by default — this is where 90% of users actually
         // configure things. Wrapped in <details> so the rare non-template
         // user can collapse it.
@@ -774,6 +780,94 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
         rightFooter.createEl('a', { href: 'https://ko-fi.com/frostmute', text: '☕️ Support Development', attr: { target: '_blank' } });
         rightFooter.createEl('br');
         rightFooter.createEl('a', { href: 'https://github.com/frostmute/make-it-rain/issues', text: '🐛 Report an Issue', attr: { target: '_blank' } });
+    }
+
+    /**
+     * Render the saved-preset manager: one row per preset with rename and
+     * delete actions. Presets are created from the bulk import modal; this
+     * screen is where they can be reviewed and cleaned up.
+     */
+    renderImportPresets(container: HTMLElement): void {
+        container.empty();
+
+        const presets = this.plugin.settings.importPresets || [];
+
+        container.createEl('p', {
+            text: 'Presets capture a full bulk-import configuration and are saved from the "Bulk Import Raindrops" modal. Each preset also gets a "Fetch: {name}" command in the command palette.',
+            cls: 'setting-item-description'
+        });
+
+        if (presets.length === 0) {
+            container.createEl('p', {
+                text: 'No saved presets yet. Open the bulk import modal and use "Save current as preset" to create one.',
+                cls: 'setting-item-description'
+            });
+            return;
+        }
+
+        presets.forEach((preset: ImportPreset) => {
+            new Setting(container)
+                .setName(preset.name)
+                .setDesc(this.describePreset(preset))
+                .addButton((button: ButtonComponent) => {
+                    button.setButtonText('Rename')
+                        .setIcon('pencil')
+                        .setTooltip('Rename this preset')
+                        .onClick(() => {
+                            new SavePresetModal(
+                                this.app,
+                                this.plugin,
+                                preset.name,
+                                async (name: string) => {
+                                    const clash = (this.plugin.settings.importPresets || [])
+                                        .some(p => p.id !== preset.id && p.name === name);
+                                    if (clash) {
+                                        new Notice(`A preset named "${name}" already exists.`);
+                                        return;
+                                    }
+                                    preset.name = name;
+                                    await this.plugin.saveSettings();
+                                    this.plugin.refreshPresetCommands();
+                                    new Notice(`Preset renamed to "${name}".`);
+                                    this.renderImportPresets(container);
+                                },
+                                'Rename import preset',
+                                'Give this preset a new name. Its captured options and command-palette entry are preserved.'
+                            ).open();
+                        });
+                })
+                .addButton((button: ButtonComponent) => {
+                    button.setButtonText('Delete')
+                        .setIcon('trash')
+                        .setWarning()
+                        .setTooltip('Delete this preset')
+                        .onClick(async () => {
+                            this.plugin.settings.importPresets = (this.plugin.settings.importPresets || [])
+                                .filter(p => p.id !== preset.id);
+                            await this.plugin.saveSettings();
+                            this.plugin.refreshPresetCommands();
+                            new Notice(`Preset "${preset.name}" deleted.`);
+                            this.renderImportPresets(container);
+                        });
+                });
+        });
+    }
+
+    /**
+     * One-line human summary of a preset's captured options, shown under its
+     * name in the settings list.
+     */
+    private describePreset(preset: ImportPreset): string {
+        const parts: string[] = [];
+        parts.push(`Collections: ${preset.collections.trim() || 'all'}`);
+        if (preset.apiFilterTags.trim()) {
+            parts.push(`Tags (${preset.tagMatchType}): ${preset.apiFilterTags.trim()}`);
+        }
+        if (preset.filterType !== 'all') {
+            parts.push(`Type: ${preset.filterType}`);
+        }
+        parts.push(`Destination: ${preset.vaultPath.trim() || 'plugin default'}`);
+        return parts.join(' · ');
     }
 
     async verifyApiToken(): Promise<void> {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -842,9 +842,18 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                         .setWarning()
                         .setTooltip('Delete this preset')
                         .onClick(async () => {
-                            this.plugin.settings.importPresets = (this.plugin.settings.importPresets || [])
-                                .filter(p => p.id !== preset.id);
-                            await this.plugin.saveSettings();
+                            const previous = this.plugin.settings.importPresets || [];
+                            this.plugin.settings.importPresets = previous.filter(p => p.id !== preset.id);
+                            try {
+                                await this.plugin.saveSettings();
+                            } catch (e: unknown) {
+                                // Restore the list so the UI and disk agree.
+                                this.plugin.settings.importPresets = previous;
+                                console.error('Failed to delete preset:', e);
+                                new Notice(`Could not delete preset "${preset.name}": ${e instanceof Error ? e.message : String(e)}`);
+                                this.renderImportPresets(container);
+                                return;
+                            }
                             this.plugin.refreshPresetCommands();
                             new Notice(`Preset "${preset.name}" deleted.`);
                             this.renderImportPresets(container);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -822,14 +822,14 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                                     const clash = (this.plugin.settings.importPresets || [])
                                         .some(p => p.id !== preset.id && p.name === name);
                                     if (clash) {
-                                        new Notice(`A preset named "${name}" already exists.`);
-                                        return;
+                                        throw new Error(`A preset named "${name}" already exists.`);
                                     }
                                     preset.name = name;
                                     await this.plugin.saveSettings();
                                     this.plugin.refreshPresetCommands();
                                     new Notice(`Preset renamed to "${name}".`);
                                     this.renderImportPresets(container);
+                                    return true;
                                 },
                                 'Rename import preset',
                                 'Give this preset a new name. Its captured options and command-palette entry are preserved.'

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -824,8 +824,17 @@ export class RaindropToObsidianSettingTab extends PluginSettingTab {
                                     if (clash) {
                                         throw new Error(`A preset named "${name}" already exists.`);
                                     }
+                                    const previousName = preset.name;
                                     preset.name = name;
-                                    await this.plugin.saveSettings();
+                                    try {
+                                        await this.plugin.saveSettings();
+                                    } catch (e: unknown) {
+                                        // Undo the rename so a later unrelated
+                                        // save can't persist it behind the scenes.
+                                        preset.name = previousName;
+                                        this.renderImportPresets(container);
+                                        throw e;
+                                    }
                                     this.plugin.refreshPresetCommands();
                                     new Notice(`Preset renamed to "${name}".`);
                                     this.renderImportPresets(container);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -313,7 +313,8 @@ tags:
     },
     enableSafeSync: false,
     safeSyncAction: 'Prompt',
-    trashFolderLocation: '.trash'
+    trashFolderLocation: '.trash',
+    importPresets: []
 };
 
 export class RaindropToObsidianSettingTab extends PluginSettingTab {

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,31 @@ export interface MakeItRainSettings {
     enableSafeSync: boolean;
     safeSyncAction: 'Prompt' | 'Archive' | 'Delete';
     trashFolderLocation: string;
+    importPresets: ImportPreset[];
+}
+
+/**
+ * Snapshot of the fetch-modal options that a preset captures (everything
+ * except the preset's identity fields).
+ */
+export interface ImportPresetFields {
+    vaultPath: string;
+    collections: string;
+    apiFilterTags: string;
+    includeSubcollections: boolean;
+    appendTagsToNotes: string;
+    useRaindropTitleForFileName: boolean;
+    tagMatchType: 'all' | 'any';
+    filterType: RaindropType | 'all';
+    fetchOnlyNew: boolean;
+    updateExisting: boolean;
+    useDefaultTemplate: boolean;
+    overrideTemplates: boolean;
+}
+
+export interface ImportPreset extends ImportPresetFields {
+    id: string;
+    name: string;
 }
 
 export interface ModalFetchOptions {

--- a/tests/integration/presetWorkflow.test.ts
+++ b/tests/integration/presetWorkflow.test.ts
@@ -224,6 +224,37 @@ describe('Import Preset Workflow Integration', () => {
         expect(container.textContent).toContain('No saved presets yet');
     });
 
+    it('should keep the preset when a delete fails to persist', async () => {
+        plugin.settings.importPresets = [{
+            id: 'preset-1',
+            name: 'Reading backlog',
+            vaultPath: '',
+            collections: 'Reading',
+            apiFilterTags: '',
+            includeSubcollections: true,
+            appendTagsToNotes: '',
+            useRaindropTitleForFileName: true,
+            tagMatchType: 'all',
+            filterType: 'all',
+            fetchOnlyNew: true,
+            updateExisting: false,
+            useDefaultTemplate: false,
+            overrideTemplates: false
+        }];
+        jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        (plugin.saveData as jest.Mock).mockRejectedValue(new Error('disk full'));
+
+        const tab = new RaindropToObsidianSettingTab(mockApp as unknown as App, plugin);
+        const container = document.createElement('div');
+        tab.renderImportPresets(container);
+
+        clickButton(container, 'Delete');
+        await new Promise(process.nextTick);
+
+        expect(plugin.settings.importPresets).toHaveLength(1);
+        expect(container.textContent).toContain('Reading backlog');
+    });
+
     it('should keep the rename dialog open and surface the error on a duplicate name', async () => {
         plugin.settings.importPresets = [
             {

--- a/tests/integration/presetWorkflow.test.ts
+++ b/tests/integration/presetWorkflow.test.ts
@@ -1,0 +1,259 @@
+import RaindropToObsidian from '../../src/main';
+import { RaindropFetchModal, SavePresetModal } from '../../src/modals';
+import { RaindropToObsidianSettingTab } from '../../src/settings';
+import { mockApp, mockRequest, MockSetting } from '../setup';
+import { App, PluginManifest } from 'obsidian';
+
+/**
+ * End-to-end coverage of the saved-preset workflow: save one from the fetch
+ * modal, run the generated command-palette entry, then rename and delete it
+ * from the settings tab.
+ */
+describe('Import Preset Workflow Integration', () => {
+    let plugin: RaindropToObsidian;
+    let openedNameModals: SavePresetModal[];
+    let openSpy: jest.SpyInstance;
+
+    const manifest = {
+        id: 'make-it-rain',
+        name: 'Make It Rain',
+        author: 'frostmute',
+        version: '2.1.1',
+        minAppVersion: '1.13.0',
+        description: 'Raindrop.io Integration'
+    } as PluginManifest;
+
+    /** Click a button by its label inside a rendered container. */
+    const clickButton = (container: HTMLElement, label: string): void => {
+        const button = Array.from(container.querySelectorAll('button'))
+            .find(candidate => candidate.textContent === label);
+        expect(button).toBeDefined();
+        button!.click();
+    };
+
+    /** Type a name into the most recently opened name dialog and save it. */
+    const submitName = async (name: string): Promise<SavePresetModal> => {
+        const nameModal = openedNameModals[openedNameModals.length - 1];
+        expect(nameModal).toBeDefined();
+        (nameModal.contentEl.querySelector('input') as HTMLInputElement).value = name;
+        clickButton(nameModal.contentEl, 'Save');
+        await new Promise(process.nextTick);
+        return nameModal;
+    };
+
+    beforeEach(() => {
+        plugin = new RaindropToObsidian(mockApp as unknown as App, manifest);
+        plugin.settings.apiToken = 'valid-token';
+        plugin.settings.defaultFolder = 'Raindrops';
+        plugin.settings.importPresets = [];
+        jest.clearAllMocks();
+        jest.spyOn(plugin, 'fetchAllUserCollections').mockResolvedValue([]);
+        jest.spyOn(plugin, 'saveData').mockResolvedValue(undefined);
+
+        // The Obsidian Modal mock's open() is a no-op; render the name dialog
+        // so tests can drive it like a user would.
+        openedNameModals = [];
+        openSpy = jest.spyOn(SavePresetModal.prototype, 'open')
+            .mockImplementation(function (this: SavePresetModal) {
+                openedNameModals.push(this);
+                this.onOpen();
+            });
+    });
+
+    afterEach(() => {
+        openSpy.mockRestore();
+    });
+
+    it('should save a preset from the modal and import through its command-palette entry', async () => {
+        const addCommandSpy = jest.spyOn(plugin, 'addCommand');
+
+        const modal = new RaindropFetchModal(mockApp as unknown as App, plugin);
+        modal.onOpen();
+        modal.collections = '';
+        modal.apiFilterTags = 'css';
+        modal.vaultPath = 'Imports/Reading';
+        modal.useDefaultTemplate = true;
+
+        clickButton(modal.contentEl, 'Save current as preset');
+        await submitName('Reading backlog');
+
+        expect(plugin.settings.importPresets).toHaveLength(1);
+        const [saved] = plugin.settings.importPresets;
+        expect(saved.name).toBe('Reading backlog');
+        expect(saved.apiFilterTags).toBe('css');
+        expect(saved.vaultPath).toBe('Imports/Reading');
+        expect(modal.selectedPresetId).toBe(saved.id);
+
+        const commandCall = addCommandSpy.mock.calls
+            .find(call => (call[0] as { id: string }).id === `fetch-preset-${saved.id}`);
+        expect(commandCall).toBeDefined();
+
+        (mockRequest as jest.Mock).mockImplementation((options: { url: string }) => {
+            if (options.url.endsWith('/collections') || options.url.endsWith('/collections/childrens')) {
+                return Promise.resolve(JSON.stringify({
+                    result: true,
+                    items: options.url.endsWith('/collections') ? [{ _id: 123, title: 'Reading' }] : []
+                }));
+            }
+            if (options.url.includes('/raindrops/')) {
+                return Promise.resolve(JSON.stringify({
+                    result: true,
+                    items: [{
+                        _id: 42,
+                        title: 'Preset Raindrop',
+                        link: 'https://example.com',
+                        tags: ['css'],
+                        lastUpdate: '2024-01-01T12:00:00Z',
+                        type: 'link'
+                    }]
+                }));
+            }
+            return Promise.resolve(JSON.stringify({ result: true, items: [] }));
+        });
+        const createSpy = jest.spyOn(mockApp.vault, 'create');
+        jest.spyOn(mockApp.vault.adapter, 'exists').mockResolvedValue(false);
+        (plugin.fetchAllUserCollections as jest.Mock).mockRestore();
+
+        const fetchSpy = jest.spyOn(plugin, 'fetchRaindrops');
+        (commandCall![0] as { callback?: () => void }).callback?.();
+        await fetchSpy.mock.results[0].value;
+
+        expect(fetchSpy).toHaveBeenCalledWith(expect.objectContaining({
+            apiFilterTags: 'css',
+            vaultPath: 'Imports/Reading'
+        }));
+        expect(createSpy).toHaveBeenCalled();
+        expect(createSpy.mock.calls[0][0]).toContain('Preset Raindrop.md');
+    });
+
+    it('should restore defaults when the preset selection is cleared in the modal', () => {
+        plugin.settings.importPresets = [{
+            id: 'preset-1',
+            name: 'Reading backlog',
+            vaultPath: 'Imports/Reading',
+            collections: 'Reading',
+            apiFilterTags: 'css',
+            includeSubcollections: false,
+            appendTagsToNotes: '#imported',
+            useRaindropTitleForFileName: false,
+            tagMatchType: 'any',
+            filterType: 'article',
+            fetchOnlyNew: false,
+            updateExisting: true,
+            useDefaultTemplate: false,
+            overrideTemplates: true
+        }];
+
+        const addDropdownSpy = jest.spyOn(MockSetting.prototype, 'addDropdown');
+        const modal = new RaindropFetchModal(mockApp as unknown as App, plugin);
+        modal.onOpen();
+
+        // Replay the preset dropdown's callback with a stub component so the
+        // real onChange handler can be exercised.
+        const handlers: ((value: string) => void)[] = [];
+        const stub: Record<string, unknown> = {};
+        stub.addOption = () => stub;
+        stub.setValue = () => stub;
+        stub.onChange = (handler: (value: string) => void) => {
+            handlers.push(handler);
+            return stub;
+        };
+        (addDropdownSpy.mock.calls[0][0] as (component: unknown) => void)(stub);
+        const onChange = handlers[0];
+        addDropdownSpy.mockRestore();
+
+        onChange('preset-1');
+        expect(modal.selectedPresetId).toBe('preset-1');
+        expect(modal.collections).toBe('Reading');
+        expect(modal.filterType).toBe('article');
+
+        onChange('');
+        expect(modal.selectedPresetId).toBe('');
+        expect(modal.collections).toBe('');
+        expect(modal.apiFilterTags).toBe('');
+        expect(modal.filterType).toBe('all');
+        expect(modal.vaultPath).toBe('Raindrops');
+        expect(modal.updateExisting).toBe(false);
+    });
+
+    it('should rename and delete a preset from the settings tab, keeping commands in sync', async () => {
+        plugin.settings.importPresets = [{
+            id: 'preset-1',
+            name: 'Reading backlog',
+            vaultPath: '',
+            collections: 'Reading',
+            apiFilterTags: '',
+            includeSubcollections: true,
+            appendTagsToNotes: '',
+            useRaindropTitleForFileName: true,
+            tagMatchType: 'all',
+            filterType: 'all',
+            fetchOnlyNew: true,
+            updateExisting: false,
+            useDefaultTemplate: false,
+            overrideTemplates: false
+        }];
+
+        const addCommandSpy = jest.spyOn(plugin, 'addCommand');
+        const removeCommandSpy = jest.spyOn(plugin, 'removeCommand');
+        plugin.refreshPresetCommands();
+
+        const tab = new RaindropToObsidianSettingTab(mockApp as unknown as App, plugin);
+        const container = document.createElement('div');
+        tab.renderImportPresets(container);
+        expect(container.textContent).toContain('Reading backlog');
+        expect(container.textContent).toContain('Collections: Reading');
+
+        addCommandSpy.mockClear();
+        clickButton(container, 'Rename');
+        await submitName('Weekly reading');
+
+        expect(plugin.settings.importPresets[0].name).toBe('Weekly reading');
+        expect(plugin.settings.importPresets[0].id).toBe('preset-1');
+        expect(addCommandSpy).toHaveBeenCalledWith(expect.objectContaining({
+            id: 'fetch-preset-preset-1',
+            name: 'Fetch: Weekly reading'
+        }));
+        expect(container.textContent).toContain('Weekly reading');
+
+        clickButton(container, 'Delete');
+        await new Promise(process.nextTick);
+
+        expect(plugin.settings.importPresets).toHaveLength(0);
+        expect(removeCommandSpy).toHaveBeenCalledWith('fetch-preset-preset-1');
+        expect(container.textContent).toContain('No saved presets yet');
+    });
+
+    it('should keep the rename dialog open and surface the error on a duplicate name', async () => {
+        plugin.settings.importPresets = [
+            {
+                id: 'preset-1', name: 'One', vaultPath: '', collections: '', apiFilterTags: '',
+                includeSubcollections: true, appendTagsToNotes: '', useRaindropTitleForFileName: true,
+                tagMatchType: 'all', filterType: 'all', fetchOnlyNew: true, updateExisting: false,
+                useDefaultTemplate: false, overrideTemplates: false
+            },
+            {
+                id: 'preset-2', name: 'Two', vaultPath: '', collections: '', apiFilterTags: '',
+                includeSubcollections: true, appendTagsToNotes: '', useRaindropTitleForFileName: true,
+                tagMatchType: 'all', filterType: 'all', fetchOnlyNew: true, updateExisting: false,
+                useDefaultTemplate: false, overrideTemplates: false
+            }
+        ];
+
+        const tab = new RaindropToObsidianSettingTab(mockApp as unknown as App, plugin);
+        const container = document.createElement('div');
+        tab.renderImportPresets(container);
+
+        const renameButtons = Array.from(container.querySelectorAll('button'))
+            .filter(button => button.textContent === 'Rename');
+        renameButtons[1].click();
+
+        const closeSpy = jest.spyOn(openedNameModals[openedNameModals.length - 1] ?? SavePresetModal.prototype, 'close');
+        jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        const nameModal = await submitName('One');
+
+        expect(closeSpy).not.toHaveBeenCalled();
+        expect(nameModal.contentEl.textContent).toContain('A preset named "One" already exists.');
+        expect(plugin.settings.importPresets[1].name).toBe('Two');
+    });
+});

--- a/tests/integration/presetWorkflow.test.ts
+++ b/tests/integration/presetWorkflow.test.ts
@@ -151,7 +151,7 @@ describe('Import Preset Workflow Integration', () => {
         // Replay the preset dropdown's callback with a stub component so the
         // real onChange handler can be exercised.
         const handlers: ((value: string) => void)[] = [];
-        const stub: Record<string, unknown> = {};
+        const stub: Record<string, unknown> = { selectEl: document.createElement('select') };
         stub.addOption = () => stub;
         stub.setValue = () => stub;
         stub.onChange = (handler: (value: string) => void) => {
@@ -222,6 +222,54 @@ describe('Import Preset Workflow Integration', () => {
         expect(plugin.settings.importPresets).toHaveLength(0);
         expect(removeCommandSpy).toHaveBeenCalledWith('fetch-preset-preset-1');
         expect(container.textContent).toContain('No saved presets yet');
+    });
+
+    it('should discard the new preset and keep the dialog open when saving fails', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        (plugin.saveData as jest.Mock).mockRejectedValue(new Error('disk full'));
+
+        const modal = new RaindropFetchModal(mockApp as unknown as App, plugin);
+        modal.onOpen();
+        modal.collections = 'Reading';
+
+        clickButton(modal.contentEl, 'Save current as preset');
+        const nameModal = await submitName('Reading backlog');
+
+        expect(plugin.settings.importPresets).toHaveLength(0);
+        expect(modal.selectedPresetId).toBe('');
+        expect(nameModal.contentEl.textContent).toContain('disk full');
+    });
+
+    it('should restore the old name and keep the dialog open when a rename fails to persist', async () => {
+        plugin.settings.importPresets = [{
+            id: 'preset-1',
+            name: 'Reading backlog',
+            vaultPath: '',
+            collections: 'Reading',
+            apiFilterTags: '',
+            includeSubcollections: true,
+            appendTagsToNotes: '',
+            useRaindropTitleForFileName: true,
+            tagMatchType: 'all',
+            filterType: 'all',
+            fetchOnlyNew: true,
+            updateExisting: false,
+            useDefaultTemplate: false,
+            overrideTemplates: false
+        }];
+        jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        (plugin.saveData as jest.Mock).mockRejectedValue(new Error('disk full'));
+
+        const tab = new RaindropToObsidianSettingTab(mockApp as unknown as App, plugin);
+        const container = document.createElement('div');
+        tab.renderImportPresets(container);
+
+        clickButton(container, 'Rename');
+        const nameModal = await submitName('Weekly reading');
+
+        expect(plugin.settings.importPresets[0].name).toBe('Reading backlog');
+        expect(container.textContent).toContain('Reading backlog');
+        expect(nameModal.contentEl.textContent).toContain('disk full');
     });
 
     it('should keep the preset when a delete fails to persist', async () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -139,6 +139,10 @@ class MockPlugin {
         // Mock implementation
     }
 
+    removeCommand(commandId: string) {
+        // Mock implementation
+    }
+
     addSettingTab(tab: any) {
         // Mock implementation
     }
@@ -247,12 +251,22 @@ class MockSetting {
     }
 
     addText(callback: (component: any) => void) {
+        // Stateful so getValue() reflects the last setValue() / DOM value,
+        // which lets tests drive text inputs through the real DOM. The input
+        // is appended to the control area like the real Setting.addText.
         const component = {
-            setValue: jest.fn().mockReturnThis(),
+            inputEl: document.createElement('input'),
+            setValue: jest.fn(function (this: any, v: string) {
+                this.inputEl.value = v;
+                return this;
+            }),
+            getValue: jest.fn(function (this: any) {
+                return this.inputEl.value;
+            }),
             setPlaceholder: jest.fn().mockReturnThis(),
-            onChange: jest.fn().mockReturnThis(),
-            inputEl: document.createElement('input')
+            onChange: jest.fn().mockReturnThis()
         };
+        this.controlEl.appendChild(component.inputEl);
         callback(component);
         return this;
     }
@@ -279,16 +293,23 @@ class MockSetting {
 
     addButton(callback: (component: any) => void) {
         const component = {
-            setButtonText: jest.fn().mockReturnThis(),
+            buttonEl: document.createElement('button'),
+            setButtonText: jest.fn(function (this: any, text: string) {
+                this.buttonEl.textContent = text;
+                return this;
+            }),
             setIcon: jest.fn().mockReturnThis(),
             setTooltip: jest.fn().mockReturnThis(),
-            onClick: jest.fn().mockReturnThis(),
+            onClick: jest.fn(function (this: any, cb: () => void) {
+                this.buttonEl.addEventListener('click', cb);
+                return this;
+            }),
             setCta: jest.fn().mockReturnThis(),
             setWarning: jest.fn().mockReturnThis(),
             setDestructive: jest.fn().mockReturnThis(),
-            setDisabled: jest.fn().mockReturnThis(),
-            buttonEl: document.createElement('button')
+            setDisabled: jest.fn().mockReturnThis()
         };
+        this.controlEl.appendChild(component.buttonEl);
         callback(component);
         return this;
     }
@@ -397,10 +418,16 @@ class MockButtonComponent {
         this.buttonEl = document.createElement('button');
         containerEl.appendChild(this.buttonEl);
     }
-    setButtonText = jest.fn().mockReturnThis();
+    setButtonText = jest.fn(function (this: any, text: string) {
+        this.buttonEl.textContent = text;
+        return this;
+    });
     setIcon = jest.fn().mockReturnThis();
     setTooltip = jest.fn().mockReturnThis();
-    onClick = jest.fn().mockReturnThis();
+    onClick = jest.fn(function (this: any, cb: () => void) {
+        this.buttonEl.addEventListener('click', cb);
+        return this;
+    });
     setCta = jest.fn().mockReturnThis();
     setWarning = jest.fn().mockReturnThis();
     setDestructive = jest.fn().mockReturnThis();

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -316,6 +316,7 @@ class MockSetting {
 
     addDropdown(callback: (component: any) => void) {
         const component = {
+            selectEl: document.createElement('select'),
             addOption: jest.fn().mockReturnThis(),
             setValue: jest.fn().mockReturnThis(),
             onChange: jest.fn().mockReturnThis()

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -232,4 +232,83 @@ describe('RaindropToObsidian', () => {
             expect(addRibbonIconSpy).not.toHaveBeenCalled();
         });
     });
+
+    describe('preset commands', () => {
+        it('should register one command per saved preset', async () => {
+            plugin.settings.importPresets = [{
+                id: 'preset-abc',
+                name: 'Reading backlog',
+                vaultPath: '',
+                collections: 'Reading',
+                apiFilterTags: '',
+                includeSubcollections: true,
+                appendTagsToNotes: '',
+                useRaindropTitleForFileName: true,
+                tagMatchType: 'all',
+                filterType: 'all',
+                fetchOnlyNew: true,
+                updateExisting: false,
+                useDefaultTemplate: false,
+                overrideTemplates: false
+            }];
+
+            const addCommandSpy = jest.spyOn(plugin, 'addCommand');
+            const fetchSpy = jest.spyOn(plugin, 'fetchRaindrops').mockResolvedValue();
+
+            plugin.refreshPresetCommands();
+
+            expect(addCommandSpy).toHaveBeenCalledWith(expect.objectContaining({
+                id: 'fetch-preset-preset-abc',
+                name: 'Fetch: Reading backlog'
+            }));
+
+            // Invoking the command should trigger a fetch with the preset's options
+            const commandCall = addCommandSpy.mock.calls.find(call => call[0]?.id === 'fetch-preset-preset-abc');
+            expect(commandCall).toBeDefined();
+            const command = commandCall?.[0];
+            expect(command).toBeDefined();
+            command?.callback?.();
+            await new Promise(process.nextTick);
+
+            expect(fetchSpy).toHaveBeenCalledWith(expect.objectContaining({
+                collections: 'Reading'
+            }));
+        });
+
+        it('should re-register commands after presets change', async () => {
+            plugin.settings.importPresets = [{
+                id: 'preset-1',
+                name: 'One',
+                vaultPath: '',
+                collections: 'A',
+                apiFilterTags: '',
+                includeSubcollections: true,
+                appendTagsToNotes: '',
+                useRaindropTitleForFileName: true,
+                tagMatchType: 'all',
+                filterType: 'all',
+                fetchOnlyNew: true,
+                updateExisting: false,
+                useDefaultTemplate: false,
+                overrideTemplates: false
+            }];
+
+            const removeCommandSpy = jest.spyOn(plugin, 'removeCommand');
+            const addCommandSpy = jest.spyOn(plugin, 'addCommand');
+
+            plugin.refreshPresetCommands();
+            expect(removeCommandSpy).not.toHaveBeenCalled();
+            expect(addCommandSpy).toHaveBeenCalledWith(expect.objectContaining({ id: 'fetch-preset-preset-1' }));
+
+            // Rename the preset and refresh again: the old id is removed, the new one added.
+            plugin.settings.importPresets[0].name = 'Two';
+            plugin.refreshPresetCommands();
+
+            expect(removeCommandSpy).toHaveBeenCalledWith('fetch-preset-preset-1');
+            expect(addCommandSpy).toHaveBeenCalledWith(expect.objectContaining({
+                id: 'fetch-preset-preset-1',
+                name: 'Fetch: Two'
+            }));
+        });
+    });
 });

--- a/tests/unit/modals.test.ts
+++ b/tests/unit/modals.test.ts
@@ -1,7 +1,8 @@
 import RaindropToObsidian from '../../src/main';
-import { RaindropFetchModal, QuickImportModal, VariableBrowserModal } from '../../src/modals';
+import { RaindropFetchModal, QuickImportModal, VariableBrowserModal, SavePresetModal, upsertPreset, importPresetToOptions } from '../../src/modals';
 import { mockApp } from '../setup';
 import { App, PluginManifest } from 'obsidian';
+import { ImportPreset, ImportPresetFields } from '../../src/types';
 
 describe('Modals', () => {
     let plugin: RaindropToObsidian;
@@ -61,6 +62,169 @@ describe('Modals', () => {
             expect(modal.contentEl.innerHTML).toContain('Variable Browser');
             expect(modal.contentEl.innerHTML).toContain('{{title}}');
             expect(modal.contentEl.innerHTML).toContain('{{excerpt}}');
+        });
+    });
+
+    describe('RaindropFetchModal presets', () => {
+        const preset: ImportPreset = {
+            id: 'preset-1',
+            name: 'Reading backlog',
+            vaultPath: 'Inbox/Reading',
+            collections: 'Reading',
+            apiFilterTags: 'css, typescript',
+            includeSubcollections: false,
+            appendTagsToNotes: '#imported',
+            useRaindropTitleForFileName: true,
+            tagMatchType: 'any',
+            filterType: 'article',
+            fetchOnlyNew: false,
+            updateExisting: true,
+            useDefaultTemplate: false,
+            overrideTemplates: true
+        };
+
+        it('should render the preset section listing saved presets', () => {
+            plugin.settings.importPresets = [preset];
+            jest.spyOn(plugin, 'fetchAllUserCollections').mockResolvedValue([]);
+
+            const modal = new RaindropFetchModal(mockApp as unknown as App, plugin);
+            modal.onOpen();
+
+            expect(modal.contentEl.innerHTML).toContain('Import preset');
+            expect(modal.contentEl.innerHTML).toContain('Save current as preset');
+        });
+
+        it('should apply a preset to all modal fields', () => {
+            plugin.settings.importPresets = [preset];
+            jest.spyOn(plugin, 'fetchAllUserCollections').mockResolvedValue([]);
+
+            const modal = new RaindropFetchModal(mockApp as unknown as App, plugin);
+            (modal as unknown as { applyPreset(p: ImportPreset): void }).applyPreset(preset);
+
+            expect(modal.vaultPath).toBe('Inbox/Reading');
+            expect(modal.collections).toBe('Reading');
+            expect(modal.apiFilterTags).toBe('css, typescript');
+            expect(modal.includeSubcollections).toBe(false);
+            expect(modal.appendTagsToNotes).toBe('#imported');
+            expect(modal.tagMatchType).toBe('any');
+            expect(modal.filterType).toBe('article');
+            expect(modal.fetchOnlyNew).toBe(false);
+            expect(modal.updateExisting).toBe(true);
+            expect(modal.useDefaultTemplate).toBe(false);
+            expect(modal.overrideTemplates).toBe(true);
+        });
+
+        it('should snapshot current fields into preset payload and fetch options', () => {
+            jest.spyOn(plugin, 'fetchAllUserCollections').mockResolvedValue([]);
+
+            const modal = new RaindropFetchModal(mockApp as unknown as App, plugin);
+            modal.vaultPath = 'Books';
+            modal.collections = 'Tech';
+            modal.apiFilterTags = 'react';
+            modal.includeSubcollections = false;
+            modal.appendTagsToNotes = '#dev';
+            modal.useRaindropTitleForFileName = false;
+            modal.tagMatchType = 'any';
+            modal.filterType = 'video';
+            modal.fetchOnlyNew = false;
+            modal.updateExisting = true;
+            modal.useDefaultTemplate = true;
+            modal.overrideTemplates = false;
+
+            const fields = (modal as unknown as { toPresetFields(): ImportPresetFields }).toPresetFields();
+            expect(fields.collections).toBe('Tech');
+            expect(fields.tagMatchType).toBe('any');
+            expect(fields.filterType).toBe('video');
+            expect(fields.updateExisting).toBe(true);
+
+            const options = (modal as unknown as { getFetchOptions(): ReturnType<typeof importPresetToOptions> }).getFetchOptions();
+            expect(options).toEqual(importPresetToOptions(fields));
+            expect(options.vaultPath).toBe('Books');
+            expect(options.collections).toBe('Tech');
+        });
+    });
+
+    describe('SavePresetModal', () => {
+        it('should submit the entered name', async () => {
+            const onSubmit = jest.fn().mockResolvedValue(undefined);
+            const modal = new SavePresetModal(mockApp as unknown as App, plugin, '', onSubmit);
+            modal.onOpen();
+
+            expect(modal.contentEl.innerHTML).toContain('Save import preset');
+            const input = modal.contentEl.querySelector('input');
+            expect(input).not.toBeNull();
+            (input as HTMLInputElement).value = 'Reading backlog';
+
+            const saveButton = Array.from(modal.contentEl.querySelectorAll('button'))
+                .find(button => button.textContent === 'Save');
+            expect(saveButton).toBeDefined();
+            saveButton!.click();
+
+            await new Promise(process.nextTick);
+            expect(onSubmit).toHaveBeenCalledWith('Reading backlog');
+        });
+
+        it('should not submit an empty name', async () => {
+            const onSubmit = jest.fn();
+            const modal = new SavePresetModal(mockApp as unknown as App, plugin, '', onSubmit);
+            modal.onOpen();
+
+            const saveButton = Array.from(modal.contentEl.querySelectorAll('button'))
+                .find(button => button.textContent === 'Save');
+            saveButton!.click();
+
+            await new Promise(process.nextTick);
+            expect(onSubmit).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('preset helpers', () => {
+        const fields: ImportPresetFields = {
+            vaultPath: '',
+            collections: 'Reading',
+            apiFilterTags: 'css',
+            includeSubcollections: true,
+            appendTagsToNotes: '',
+            useRaindropTitleForFileName: true,
+            tagMatchType: 'all',
+            filterType: 'all',
+            fetchOnlyNew: true,
+            updateExisting: false,
+            useDefaultTemplate: false,
+            overrideTemplates: false
+        };
+
+        it('upsertPreset should create then update by name, keeping the id', () => {
+            let presets: ImportPreset[] = [];
+            const created = upsertPreset(presets, 'Weekly', fields);
+            presets = created.presets;
+
+            expect(created.created).toBe(true);
+            expect(presets).toHaveLength(1);
+            expect(presets[0].name).toBe('Weekly');
+            expect(presets[0].id).toMatch(/^preset-/);
+
+            const updated = upsertPreset(presets, 'Weekly', { ...fields, collections: 'Archive' });
+            expect(updated.created).toBe(false);
+            expect(updated.presets).toHaveLength(1);
+            expect(updated.preset.id).toBe(presets[0].id);
+            expect(updated.preset.collections).toBe('Archive');
+        });
+
+        it('importPresetToOptions should map every preset field', () => {
+            const options = importPresetToOptions(fields);
+            expect(options.collections).toBe('Reading');
+            expect(options.apiFilterTags).toBe('css');
+            expect(options.includeSubcollections).toBe(true);
+            expect(options.tagMatchType).toBe('all');
+            expect(options.filterType).toBe('all');
+            expect(options.fetchOnlyNew).toBe(true);
+            expect(options.updateExisting).toBe(false);
+            expect(options.useDefaultTemplate).toBe(false);
+            expect(options.overrideTemplates).toBe(false);
+            expect(options.vaultPath).toBe('');
+            expect(options.appendTagsToNotes).toBe('');
+            expect(options.useRaindropTitleForFileName).toBe(true);
         });
     });
 });

--- a/tests/unit/modals.test.ts
+++ b/tests/unit/modals.test.ts
@@ -114,6 +114,32 @@ describe('Modals', () => {
             expect(modal.overrideTemplates).toBe(true);
         });
 
+        it('should restore defaults when the preset selection is cleared', () => {
+            plugin.settings.importPresets = [preset];
+            plugin.settings.defaultFolder = 'Raindrops';
+            jest.spyOn(plugin, 'fetchAllUserCollections').mockResolvedValue([]);
+
+            const modal = new RaindropFetchModal(mockApp as unknown as App, plugin);
+            (modal as unknown as { applyPreset(p: ImportPreset): void }).applyPreset(preset);
+            modal.selectedPresetId = preset.id;
+
+            modal.resetToDefaults();
+            modal.selectedPresetId = '';
+
+            expect(modal.vaultPath).toBe('Raindrops');
+            expect(modal.collections).toBe('');
+            expect(modal.apiFilterTags).toBe('');
+            expect(modal.includeSubcollections).toBe(true);
+            expect(modal.appendTagsToNotes).toBe('');
+            expect(modal.useRaindropTitleForFileName).toBe(true);
+            expect(modal.tagMatchType).toBe('all');
+            expect(modal.filterType).toBe('all');
+            expect(modal.fetchOnlyNew).toBe(true);
+            expect(modal.updateExisting).toBe(false);
+            expect(modal.useDefaultTemplate).toBe(false);
+            expect(modal.overrideTemplates).toBe(false);
+        });
+
         it('should snapshot current fields into preset payload and fetch options', () => {
             jest.spyOn(plugin, 'fetchAllUserCollections').mockResolvedValue([]);
 

--- a/tests/unit/modals.test.ts
+++ b/tests/unit/modals.test.ts
@@ -1,5 +1,5 @@
 import RaindropToObsidian from '../../src/main';
-import { RaindropFetchModal, QuickImportModal, VariableBrowserModal, SavePresetModal, upsertPreset, importPresetToOptions } from '../../src/modals';
+import { RaindropFetchModal, QuickImportModal, VariableBrowserModal, SavePresetModal, upsertPreset, importPresetToOptions, normalizeImportPresets } from '../../src/modals';
 import { mockApp } from '../setup';
 import { App, PluginManifest } from 'obsidian';
 import { ImportPreset, ImportPresetFields } from '../../src/types';
@@ -251,6 +251,45 @@ describe('Modals', () => {
             expect(options.vaultPath).toBe('');
             expect(options.appendTagsToNotes).toBe('');
             expect(options.useRaindropTitleForFileName).toBe(true);
+        });
+
+        it('normalizeImportPresets should coerce malformed records and drop unusable ones', () => {
+            const normalized = normalizeImportPresets([
+                null,
+                'not-a-preset',
+                { name: 'No id' },
+                { id: 'p-1' },
+                {
+                    id: 'p-2',
+                    name: 'Partial',
+                    collections: 42,
+                    tagMatchType: 'weird',
+                    filterType: 'nonsense',
+                    updateExisting: 'yes'
+                }
+            ]);
+
+            expect(normalized).toHaveLength(1);
+            const [preset] = normalized;
+            expect(preset.id).toBe('p-2');
+            expect(preset.collections).toBe('');
+            expect(preset.apiFilterTags).toBe('');
+            expect(preset.vaultPath).toBe('');
+            expect(preset.tagMatchType).toBe('all');
+            expect(preset.filterType).toBe('all');
+            expect(preset.updateExisting).toBe(false);
+            expect(preset.includeSubcollections).toBe(true);
+            expect(preset.fetchOnlyNew).toBe(true);
+        });
+
+        it('normalizeImportPresets should return an empty list for non-array data', () => {
+            expect(normalizeImportPresets(undefined)).toEqual([]);
+            expect(normalizeImportPresets({ nope: true })).toEqual([]);
+        });
+
+        it('normalizeImportPresets should preserve valid records', () => {
+            const valid: ImportPreset = { id: 'p-1', name: 'Weekly', ...fields, filterType: 'article', tagMatchType: 'any' };
+            expect(normalizeImportPresets([valid])).toEqual([valid]);
         });
     });
 });


### PR DESCRIPTION
## Summary

Adds **saved import presets** for the bulk fetch workflow. Users can capture the full fetch-modal configuration as a named preset and reuse it in one click — no more re-entering collections, tag filters, folders, and toggles on every import.

## What's included

- **Presets section in the fetch modal** (`RaindropFetchModal`): a dropdown listing saved presets plus a **Save current as preset** and **Delete preset** action. Selecting a preset applies all captured options and re-renders the modal.
- **Full option coverage**: collections, tag filter + match type (AND/OR), content type filter, include subcollections, save destination, append tags, use-Raindrop-title-for-filename, fetch-only-new / update-existing, and both template overrides.
- **Per-preset command-palette entries**: each preset registers a `Fetch: {preset name}` command, re-registered automatically when presets are created, updated, or deleted (via `Plugin.removeCommand`, available since Obsidian 1.7.2; plugin `minAppVersion` is 1.13.0).
- **Shared options mapping**: `importPresetToOptions()` keeps the live modal fetch and command fetches in lockstep.
- **Backward compatible**: existing saved settings without `importPresets` default to an empty list; modal defaults are unchanged.

## Verification

- `npm run build` (tsc + esbuild) — clean
- `npm run lint` — clean
- `npx jest` — 21 suites, 324 tests passing (new coverage for preset rendering/apply/snapshot, `SavePresetModal`, `upsertPreset` id stability, and command registration)

## Notes

- New setting field `importPresets` added to the settings schema (defaults to `[]`).
- No new dependencies; reuses existing `modals.ts` / `main.ts` / plugin-data patterns.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/frostmute/make-it-rain/pull/91" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->